### PR TITLE
feat: Update tutorial to use pyhf v0.6.2

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --no-cache-dir -r binder/requirements.txt
-        python -m pip install --no-cache-dir -r book/requirements.txt
+        python -m pip --no-cache-dir install -r binder/requirements.txt
+        python -m pip --no-cache-dir install -r book/requirements.txt
 
     - name: Build the book
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -31,7 +31,7 @@ jobs:
         jupyter-book build book/
 
     - name: Deploy Jupyter book to GitHub pages
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      # if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -2,8 +2,8 @@ name: Deploy Jupyter Book
 
 on:
   push:
-    # branches:
-    # - main
+    branches:
+    - main
   pull_request:
   workflow_dispatch:
 
@@ -31,7 +31,7 @@ jobs:
         jupyter-book build book/
 
     - name: Deploy Jupyter book to GitHub pages
-      # if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -2,8 +2,8 @@ name: Deploy Jupyter Book
 
 on:
   push:
-    branches:
-    - main
+    # branches:
+    # - main
   pull_request:
   workflow_dispatch:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
     - id: check-added-large-files
     - id: check-case-conflict
@@ -16,22 +16,22 @@ repos:
     - id: mixed-line-ending
     - id: trailing-whitespace
 
--   repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-    - id: black
-
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.11.0
+    rev: v2.19.4
     hooks:
     -   id: pyupgrade
 
--   repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.6.0
+-   repo: https://github.com/psf/black
+    rev: 21.6b0
     hooks:
-    - id: nbqa-black
-      additional_dependencies: [black==20.8b1]
+    - id: black
+
+-   repo: https://github.com/nbQA-dev/nbQA
+    rev: 0.13.0
+    hooks:
     - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==2.11.0]
+      additional_dependencies: [pyupgrade==2.19.4]
     - id: nbqa-isort
-      additional_dependencies: [isort==5.8.0]
+      additional_dependencies: [isort==5.9.1]
+    - id: nbqa-black
+      additional_dependencies: [black==21.6b0]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tutorial last given at the [April 2021 PyHEP topical meeting](https://indico.cern.ch/event/985425/).
 
-**The tutorial is based off of [`pyhf` `v0.6.1`](https://pypi.org/project/pyhf/0.6.1/)**
+**The tutorial is based off of [`pyhf` `v0.6.2`](https://pypi.org/project/pyhf/0.6.2/)**
 
 [![Deploy Jupyter Book](https://github.com/pyhf/pyhf-tutorial/workflows/Deploy%20Jupyter%20Book/badge.svg?branch=main)](https://pyhf.github.io/pyhf-tutorial/)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyhf/pyhf-tutorial/main?urlpath=lab)

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-pyhf[xmlio,minuit,contrib]==0.6.1
+pyhf[xmlio,minuit,contrib]==0.6.2
 # visualization
 ipywidgets~=7.5
 pandas~=1.0

--- a/book/HelloWorld.ipynb
+++ b/book/HelloWorld.ipynb
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What did we just make? This returns a [`pyhf.pdf.Model`](https://pyhf.readthedocs.io/en/v0.6.1/_generated/pyhf.pdf.Model.html#pyhf.pdf.Model) object. Let's check out the specification."
+    "What did we just make? This returns a [`pyhf.pdf.Model`](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.pdf.Model.html#pyhf.pdf.Model) object. Let's check out the specification."
    ]
   },
   {
@@ -144,7 +144,7 @@
     "\n",
     "where $n = \\{n_1, n_2\\}$ for a 2-bin model (we're being slightly fast and loose with our mathematical notation here), and similarly for $s$, $b$, and $\\gamma$.\n",
     "\n",
-    "The 'shapesys' is defined in the [HistFactory paper](https://cds.cern.ch/record/1456844)... however, it can be a little hard to extract out the necessary information. We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.1/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
+    "The 'shapesys' is defined in the [HistFactory paper](https://cds.cern.ch/record/1456844)... however, it can be a little hard to extract out the necessary information. We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.2/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
     "\n",
     "![modifiers and constraints](assets/modifiers_and_constraints.png)"
    ]
@@ -515,7 +515,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're not performing inference just yet. We're simply computing the 'logpdf' of the model specified by the parameters $\\theta$ against the provided data. To perform a fit, we use the [inference API](https://pyhf.readthedocs.io/en/v0.6.1/api.html#inference) via `pyhf.infer`.\n",
+    "We're not performing inference just yet. We're simply computing the 'logpdf' of the model specified by the parameters $\\theta$ against the provided data. To perform a fit, we use the [inference API](https://pyhf.readthedocs.io/en/v0.6.2/api.html#inference) via `pyhf.infer`.\n",
     "\n",
     "When fitting a model to data, we usually want to find the $\\hat{\\theta}$ which refers to the \"Maximum Likelihood Estimate\" of the model parameters. This is often referred to mathematically by\n",
     "\n",
@@ -675,7 +675,7 @@
    "source": [
     "## Simple Upper Limit\n",
     "\n",
-    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upperlimit` API](https://pyhf.readthedocs.io/en/v0.6.1/_generated/pyhf.infer.intervals.upperlimit.html), which also can calculate the upper limit by interpolating"
+    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upperlimit` API](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.infer.intervals.upperlimit.html), which also can calculate the upper limit by interpolating"
    ]
   },
   {

--- a/book/HelloWorld.ipynb
+++ b/book/HelloWorld.ipynb
@@ -39,8 +39,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = pyhf.simplemodels.hepdata_like(\n",
-    "    signal_data=[5.0, 10.0], bkg_data=[50.0, 60.0], bkg_uncerts=[5.0, 12.0]\n",
+    "model = pyhf.simplemodels.uncorrelated_background(\n",
+    "    signal=[5.0, 10.0], bkg=[50.0, 60.0], bkg_uncertainty=[5.0, 12.0]\n",
     ")\n",
     "model"
    ]
@@ -713,7 +713,7 @@
     "fig.set_size_inches(10.5, 7)\n",
     "ax.set_title(\"Hypothesis Tests\")\n",
     "\n",
-    "brazil.plot_results(ax, poi_values, results)"
+    "artists = brazil.plot_results(poi_values, results, ax=ax)"
    ]
   },
   {

--- a/book/Modifiers.ipynb
+++ b/book/Modifiers.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "In our simple examples so far, we've only used two types of modifiers, but HistFactory allows for a handful of modifiers that have proven to be sufficient to model a wide range of uncertainties.\n",
     "\n",
-    "We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.1/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
+    "We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.2/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
     "\n",
     "![modifiers and constraints](assets/modifiers_and_constraints.png)\n",
     "\n",

--- a/book/SerializationAndPatching.ipynb
+++ b/book/SerializationAndPatching.ipynb
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As of this tutorial, ATLAS has [published 7 full likelihoods to HEPData](https://pyhf.readthedocs.io/en/v0.6.1/citations.html#published-likelihoods)\n",
+    "As of this tutorial, ATLAS has [published 7 full likelihoods to HEPData](https://pyhf.readthedocs.io/en/v0.6.2/citations.html#published-likelihoods)\n",
     "\n",
     "<p align=\"center\">\n",
     "<a href=\"https://www.hepdata.net/record/ins1755298?version=3\"><img src=\"https://raw.githubusercontent.com/matthewfeickert/talk-SciPy-2020/e0c509cd0dfef98f5876071edd4c60aff9199a1b/figures/HEPData_likelihoods.png\"></a>\n",
@@ -107,7 +107,7 @@
    "source": [
     "## Patching in Signals\n",
     "\n",
-    "Let's look at this [`pyhf.PatchSet`](https://pyhf.readthedocs.io/en/v0.6.1/_generated/pyhf.patchset.PatchSet.html#pyhf.patchset.PatchSet) object which provides a user-friendly way to interact with many signal patches at once.\n",
+    "Let's look at this [`pyhf.PatchSet`](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.patchset.PatchSet.html#pyhf.patchset.PatchSet) object which provides a user-friendly way to interact with many signal patches at once.\n",
     "\n",
     "### PatchSet"
    ]

--- a/book/SerializationAndPatching.ipynb
+++ b/book/SerializationAndPatching.ipynb
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As of this tutorial, ATLAS has [published 7 full likelihoods to HEPData](https://pyhf.readthedocs.io/en/v0.6.2/citations.html#published-likelihoods)\n",
+    "As of this tutorial, ATLAS has [published 8 full statistical models to HEPData](https://pyhf.readthedocs.io/en/v0.6.2/citations.html#published-statistical-models)\n",
     "\n",
     "<p align=\"center\">\n",
     "<a href=\"https://www.hepdata.net/record/ins1755298?version=3\"><img src=\"https://raw.githubusercontent.com/matthewfeickert/talk-SciPy-2020/e0c509cd0dfef98f5876071edd4c60aff9199a1b/figures/HEPData_likelihoods.png\"></a>\n",

--- a/book/SimpleWorkspace.ipynb
+++ b/book/SimpleWorkspace.ipynb
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What did we just make? This returns a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.1/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object. Let's check out the specification."
+    "What did we just make? This returns a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object. Let's check out the specification."
    ]
   },
   {
@@ -158,7 +158,7 @@
    "source": [
     "What does this mean for us though? Well, when we ask for a model, we specify the measurement that we want to use with it. Each of these measurements above have no additional parameter configurations on top of the existing model specification. Additionally, they all declare that the parameter of interest is `mu`.\n",
     "\n",
-    "See the [documentation](https://pyhf.readthedocs.io/en/v0.6.1/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace.model) for more information. In this case, let's build the model for the default measurement."
+    "See the [documentation](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace.model) for more information. In this case, let's build the model for the default measurement."
    ]
   },
   {

--- a/book/SimpleWorkspace.ipynb
+++ b/book/SimpleWorkspace.ipynb
@@ -35,8 +35,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = pyhf.simplemodels.hepdata_like(\n",
-    "    signal_data=[5.0, 10.0], bkg_data=[50.0, 60.0], bkg_uncerts=[5.0, 12.0]\n",
+    "model = pyhf.simplemodels.uncorrelated_background(\n",
+    "    signal=[5.0, 10.0], bkg=[50.0, 60.0], bkg_uncertainty=[5.0, 12.0]\n",
     ")\n",
     "print(json.dumps(model.spec, indent=2))"
    ]

--- a/book/Toys.ipynb
+++ b/book/Toys.ipynb
@@ -25,8 +25,8 @@
     "import numpy as np\n",
     "import pyhf\n",
     "\n",
-    "model = pyhf.simplemodels.hepdata_like(\n",
-    "    signal_data=[5.0, 10.0], bkg_data=[50.0, 60.0], bkg_uncerts=[5.0, 12.0]\n",
+    "model = pyhf.simplemodels.uncorrelated_background(\n",
+    "    signal=[5.0, 10.0], bkg=[50.0, 60.0], bkg_uncertainty=[5.0, 12.0]\n",
     ")"
    ]
   },
@@ -106,8 +106,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_low = pyhf.simplemodels.hepdata_like(\n",
-    "    signal_data=[0.5, 1.0], bkg_data=[5.0, 6.0], bkg_uncerts=[0.5, 1.2]\n",
+    "model_low = pyhf.simplemodels.uncorrelated_background(\n",
+    "    signal=[0.5, 1.0], bkg=[5.0, 6.0], bkg_uncertainty=[0.5, 1.2]\n",
     ")"
    ]
   },

--- a/book/UsingCalculators.ipynb
+++ b/book/UsingCalculators.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = pyhf.simplemodels.hepdata_like([6], [9], [3])\n",
+    "model = pyhf.simplemodels.uncorrelated_background([6], [9], [3])\n",
     "data = [9] + model.config.auxdata"
    ]
   },

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "### via the command line\n",
     "\n",
-    "So pyhf comes with a lot of nifty utilities you can access. The documentation for the command line can be found via `pyhf --help` or [online](https://pyhf.readthedocs.io/en/v0.6.1/cli.html)."
+    "So pyhf comes with a lot of nifty utilities you can access. The documentation for the command line can be found via `pyhf --help` or [online](https://pyhf.readthedocs.io/en/v0.6.2/cli.html)."
    ]
   },
   {
@@ -117,7 +117,7 @@
     "python -m pip install pyhf[xmlio]\n",
     "```\n",
     "\n",
-    "Again, the online documentation for this option is found [here](https://pyhf.readthedocs.io/en/v0.6.1/cli.html#pyhf-xml2json)."
+    "Again, the online documentation for this option is found [here](https://pyhf.readthedocs.io/en/v0.6.2/cli.html#pyhf-xml2json)."
    ]
   },
   {
@@ -180,7 +180,7 @@
     "\n",
     "Nearly at the end, the next part of this specification is for the `observations` (observed data) on line 113. Each observation corresponds with the channel, where `channel1` has two bins, and `channel2` also has two bins.\n",
     "\n",
-    "Finally, we have a `version` which specifies the version of the schema used for the JSON HistFactory. In this case, we're using `1.0.0` which has the [https://pyhf.readthedocs.io/en/v0.6.1/schemas/1.0.0/workspace.json](https://pyhf.readthedocs.io/en/v0.6.1/schemas/1.0.0/workspace.json) definition which refers to the [https://pyhf.readthedocs.io/en/v0.6.1/schemas/1.0.0/defs.json](https://pyhf.readthedocs.io/en/v0.6.1/schemas/1.0.0/defs.json).\n",
+    "Finally, we have a `version` which specifies the version of the schema used for the JSON HistFactory. In this case, we're using `1.0.0` which has the [https://pyhf.readthedocs.io/en/v0.6.2/schemas/1.0.0/workspace.json](https://pyhf.readthedocs.io/en/v0.6.2/schemas/1.0.0/workspace.json) definition which refers to the [https://pyhf.readthedocs.io/en/v0.6.2/schemas/1.0.0/defs.json](https://pyhf.readthedocs.io/en/v0.6.2/schemas/1.0.0/defs.json).\n",
     "\n",
     "What's really nice about the schema definition is that it allows anyone to write their own tooling/scripting to build up the workspace and quickly check if it matches the schema. This will get you 90% of the way there in having a valid workspace to work with.\n",
     "\n",
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So we're not going to dump this out. We already did that above. Let's just quickly go ahead and load it into a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.1/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object because we can."
+    "So we're not going to dump this out. We already did that above. Let's just quickly go ahead and load it into a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object because we can."
    ]
   },
   {

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -117,7 +117,7 @@ The 'minuit' extra installs [`iminuit`](https://iminuit.readthedocs.io/).
 ````
 
 
-See our [installation docs](https://pyhf.readthedocs.io/en/v0.6.1/installation.html) for more information about installation options.
+See our [installation docs](https://pyhf.readthedocs.io/en/v0.6.2/installation.html) for more information about installation options.
 
 ### Dependencies for this tutorial
 
@@ -141,8 +141,8 @@ If you want to also get the dependencies to build and explore the Jupyter Book f
 (pyhf-tutorial) $ pyhf --citation
 @software{pyhf,
   author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},
-  title = "{pyhf: v0.6.1}",
-  version = {0.6.1},
+  title = "{pyhf: v0.6.2}",
+  version = {0.6.2},
   doi = {10.5281/zenodo.1169739},
   url = {https://github.com/scikit-hep/pyhf},
 }
@@ -161,7 +161,7 @@ If you want to also get the dependencies to build and explore the Jupyter Book f
 }
 ```
 
-Alternatively, [check the website](https://pyhf.readthedocs.io/en/v0.6.1/citations.html).
+Alternatively, [check the website](https://pyhf.readthedocs.io/en/v0.6.2/citations.html).
 
 ### Statistics References
 

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -144,7 +144,8 @@ If you want to also get the dependencies to build and explore the Jupyter Book f
   title = "{pyhf: v0.6.2}",
   version = {0.6.2},
   doi = {10.5281/zenodo.1169739},
-  url = {https://github.com/scikit-hep/pyhf},
+  url = {https://doi.org/10.5281/zenodo.1169739},
+  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.2}
 }
 
 @article{pyhf_joss,


### PR DESCRIPTION
```
* Update to pyhf v0.6.2 and update API changes
   - pyhf.simplemodels.hepdata_like -> pyhf.simplemodels.uncorrelated_background
   - brazil.plot_results(ax, poi_values, results) -> brazil.plot_results(poi_values, results, ax=ax)
   - Update URLs to point to v0.6.2
* Update number of published full statistical models to 8
  - Change language from 'likelihoods' to 'statistical models' in keeping with upcoming white paper
* Update citation format
* Update pre-commit hooks
```

Resolves https://github.com/scikit-hep/pyhf/issues/1494