### PR TITLE
feat: Update tutorial to use pyhf v0.6.3

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,19 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.9' ]
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pre-commit
         pre-commit install
+
     - name: Lint with pre-commit
       run: |
         pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,21 +17,21 @@ repos:
     - id: trailing-whitespace
 
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.4
+    rev: v2.25.0
     hooks:
     -   id: pyupgrade
 
 -   repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 21.8b0
     hooks:
     - id: black
 
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.13.0
+    rev: 1.1.0
     hooks:
     - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==2.19.4]
+      additional_dependencies: [pyupgrade==2.25.0]
     - id: nbqa-isort
-      additional_dependencies: [isort==5.9.1]
+      additional_dependencies: [isort==5.9.3]
     - id: nbqa-black
-      additional_dependencies: [black==21.6b0]
+      additional_dependencies: [black==21.8b0]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tutorial last given at the [April 2021 PyHEP topical meeting](https://indico.cern.ch/event/985425/).
 
-**The tutorial is based off of [`pyhf` `v0.6.2`](https://pypi.org/project/pyhf/0.6.2/)**
+**The tutorial is based off of [`pyhf` `v0.6.3`](https://pypi.org/project/pyhf/0.6.3/)**
 
 [![Deploy Jupyter Book](https://github.com/pyhf/pyhf-tutorial/workflows/Deploy%20Jupyter%20Book/badge.svg?branch=main)](https://pyhf.github.io/pyhf-tutorial/)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyhf/pyhf-tutorial/main?urlpath=lab)

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-pyhf[xmlio,minuit,contrib]==0.6.2
+pyhf[xmlio,minuit,contrib]==0.6.3
 # visualization
 ipywidgets~=7.5
 pandas~=1.0

--- a/book/HelloWorld.ipynb
+++ b/book/HelloWorld.ipynb
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What did we just make? This returns a [`pyhf.pdf.Model`](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.pdf.Model.html#pyhf.pdf.Model) object. Let's check out the specification."
+    "What did we just make? This returns a [`pyhf.pdf.Model`](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.pdf.Model.html#pyhf.pdf.Model) object. Let's check out the specification."
    ]
   },
   {
@@ -144,7 +144,7 @@
     "\n",
     "where $n = \\{n_1, n_2\\}$ for a 2-bin model (we're being slightly fast and loose with our mathematical notation here), and similarly for $s$, $b$, and $\\gamma$.\n",
     "\n",
-    "The 'shapesys' is defined in the [HistFactory paper](https://cds.cern.ch/record/1456844)... however, it can be a little hard to extract out the necessary information. We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.2/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
+    "The 'shapesys' is defined in the [HistFactory paper](https://cds.cern.ch/record/1456844)... however, it can be a little hard to extract out the necessary information. We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.3/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
     "\n",
     "![modifiers and constraints](assets/modifiers_and_constraints.png)"
    ]
@@ -515,7 +515,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're not performing inference just yet. We're simply computing the 'logpdf' of the model specified by the parameters $\\theta$ against the provided data. To perform a fit, we use the [inference API](https://pyhf.readthedocs.io/en/v0.6.2/api.html#inference) via `pyhf.infer`.\n",
+    "We're not performing inference just yet. We're simply computing the 'logpdf' of the model specified by the parameters $\\theta$ against the provided data. To perform a fit, we use the [inference API](https://pyhf.readthedocs.io/en/v0.6.3/api.html#inference) via `pyhf.infer`.\n",
     "\n",
     "When fitting a model to data, we usually want to find the $\\hat{\\theta}$ which refers to the \"Maximum Likelihood Estimate\" of the model parameters. This is often referred to mathematically by\n",
     "\n",
@@ -675,7 +675,7 @@
    "source": [
     "## Simple Upper Limit\n",
     "\n",
-    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upperlimit` API](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.infer.intervals.upperlimit.html), which also can calculate the upper limit by interpolating"
+    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upperlimit` API](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.infer.intervals.upperlimit.html), which also can calculate the upper limit by interpolating"
    ]
   },
   {

--- a/book/Modifiers.ipynb
+++ b/book/Modifiers.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "In our simple examples so far, we've only used two types of modifiers, but HistFactory allows for a handful of modifiers that have proven to be sufficient to model a wide range of uncertainties.\n",
     "\n",
-    "We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.2/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
+    "We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.3/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
     "\n",
     "![modifiers and constraints](assets/modifiers_and_constraints.png)\n",
     "\n",

--- a/book/SerializationAndPatching.ipynb
+++ b/book/SerializationAndPatching.ipynb
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As of this tutorial, ATLAS has [published 8 full statistical models to HEPData](https://pyhf.readthedocs.io/en/v0.6.2/citations.html#published-statistical-models)\n",
+    "As of this tutorial, ATLAS has [published 8 full statistical models to HEPData](https://pyhf.readthedocs.io/en/v0.6.3/citations.html#published-statistical-models)\n",
     "\n",
     "<p align=\"center\">\n",
     "<a href=\"https://www.hepdata.net/record/ins1755298?version=3\"><img src=\"https://raw.githubusercontent.com/matthewfeickert/talk-SciPy-2020/e0c509cd0dfef98f5876071edd4c60aff9199a1b/figures/HEPData_likelihoods.png\"></a>\n",
@@ -107,7 +107,7 @@
    "source": [
     "## Patching in Signals\n",
     "\n",
-    "Let's look at this [`pyhf.PatchSet`](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.patchset.PatchSet.html#pyhf.patchset.PatchSet) object which provides a user-friendly way to interact with many signal patches at once.\n",
+    "Let's look at this [`pyhf.PatchSet`](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.patchset.PatchSet.html#pyhf.patchset.PatchSet) object which provides a user-friendly way to interact with many signal patches at once.\n",
     "\n",
     "### PatchSet"
    ]

--- a/book/SimpleWorkspace.ipynb
+++ b/book/SimpleWorkspace.ipynb
@@ -228,7 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workspace.data(model, with_aux=False)"
+    "workspace.data(model, include_auxdata=False)"
    ]
   },
   {

--- a/book/SimpleWorkspace.ipynb
+++ b/book/SimpleWorkspace.ipynb
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What did we just make? This returns a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object. Let's check out the specification."
+    "What did we just make? This returns a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object. Let's check out the specification."
    ]
   },
   {
@@ -158,7 +158,7 @@
    "source": [
     "What does this mean for us though? Well, when we ask for a model, we specify the measurement that we want to use with it. Each of these measurements above have no additional parameter configurations on top of the existing model specification. Additionally, they all declare that the parameter of interest is `mu`.\n",
     "\n",
-    "See the [documentation](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace.model) for more information. In this case, let's build the model for the default measurement."
+    "See the [documentation](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace.model) for more information. In this case, let's build the model for the default measurement."
    ]
   },
   {

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "### via the command line\n",
     "\n",
-    "So pyhf comes with a lot of nifty utilities you can access. The documentation for the command line can be found via `pyhf --help` or [online](https://pyhf.readthedocs.io/en/v0.6.2/cli.html)."
+    "So pyhf comes with a lot of nifty utilities you can access. The documentation for the command line can be found via `pyhf --help` or [online](https://pyhf.readthedocs.io/en/v0.6.3/cli.html)."
    ]
   },
   {
@@ -117,7 +117,7 @@
     "python -m pip install pyhf[xmlio]\n",
     "```\n",
     "\n",
-    "Again, the online documentation for this option is found [here](https://pyhf.readthedocs.io/en/v0.6.2/cli.html#pyhf-xml2json)."
+    "Again, the online documentation for this option is found [here](https://pyhf.readthedocs.io/en/v0.6.3/cli.html#pyhf-xml2json)."
    ]
   },
   {
@@ -180,7 +180,7 @@
     "\n",
     "Nearly at the end, the next part of this specification is for the `observations` (observed data) on line 113. Each observation corresponds with the channel, where `channel1` has two bins, and `channel2` also has two bins.\n",
     "\n",
-    "Finally, we have a `version` which specifies the version of the schema used for the JSON HistFactory. In this case, we're using `1.0.0` which has the [https://pyhf.readthedocs.io/en/v0.6.2/schemas/1.0.0/workspace.json](https://pyhf.readthedocs.io/en/v0.6.2/schemas/1.0.0/workspace.json) definition which refers to the [https://pyhf.readthedocs.io/en/v0.6.2/schemas/1.0.0/defs.json](https://pyhf.readthedocs.io/en/v0.6.2/schemas/1.0.0/defs.json).\n",
+    "Finally, we have a `version` which specifies the version of the schema used for the JSON HistFactory. In this case, we're using `1.0.0` which has the [https://pyhf.readthedocs.io/en/v0.6.3/schemas/1.0.0/workspace.json](https://pyhf.readthedocs.io/en/v0.6.3/schemas/1.0.0/workspace.json) definition which refers to the [https://pyhf.readthedocs.io/en/v0.6.3/schemas/1.0.0/defs.json](https://pyhf.readthedocs.io/en/v0.6.3/schemas/1.0.0/defs.json).\n",
     "\n",
     "What's really nice about the schema definition is that it allows anyone to write their own tooling/scripting to build up the workspace and quickly check if it matches the schema. This will get you 90% of the way there in having a valid workspace to work with.\n",
     "\n",
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So we're not going to dump this out. We already did that above. Let's just quickly go ahead and load it into a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.2/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object because we can."
+    "So we're not going to dump this out. We already did that above. Let's just quickly go ahead and load it into a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object because we can."
    ]
   },
   {

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -117,7 +117,7 @@ The 'minuit' extra installs [`iminuit`](https://iminuit.readthedocs.io/).
 ````
 
 
-See our [installation docs](https://pyhf.readthedocs.io/en/v0.6.2/installation.html) for more information about installation options.
+See our [installation docs](https://pyhf.readthedocs.io/en/v0.6.3/installation.html) for more information about installation options.
 
 ### Dependencies for this tutorial
 
@@ -141,11 +141,11 @@ If you want to also get the dependencies to build and explore the Jupyter Book f
 (pyhf-tutorial) $ pyhf --citation
 @software{pyhf,
   author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},
-  title = "{pyhf: v0.6.2}",
-  version = {0.6.2},
+  title = "{pyhf: v0.6.3}",
+  version = {0.6.3},
   doi = {10.5281/zenodo.1169739},
   url = {https://doi.org/10.5281/zenodo.1169739},
-  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.2}
+  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.3}
 }
 
 @article{pyhf_joss,
@@ -162,7 +162,7 @@ If you want to also get the dependencies to build and explore the Jupyter Book f
 }
 ```
 
-Alternatively, [check the website](https://pyhf.readthedocs.io/en/v0.6.2/citations.html).
+Alternatively, [check the website](https://pyhf.readthedocs.io/en/v0.6.3/citations.html).
 
 ### Statistics References
 

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -97,7 +97,7 @@ If you're installing from PyPI, you can also install with some of the "extras" t
 (pyhf-tutorial) $ python -m pip install pyhf[xmlio]
 ```
 
-The 'xmlio' extra additionally installs [`uproot`](https://github.com/scikit-hep/uproot) to read `ROOT` files.
+The 'xmlio' extra additionally installs [`uproot`](https://github.com/scikit-hep/uproot4) to read `ROOT` files.
 ````
 
 ````{tabbed} Use PyTorch and Tensorflow


### PR DESCRIPTION
Addresses the tutorial part of https://github.com/scikit-hep/pyhf/issues/1578

```
* Update to pyhf v0.6.3 and update API changes
   - with_aux -> include_auxdata
   - Update URLs to point to v0.6.3
* Update pre-commit hooks
* Update to using Python 3.9
```