### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,21 +17,21 @@ repos:
     - id: trailing-whitespace
 
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.25.0
+    rev: v2.29.0
     hooks:
     -   id: pyupgrade
 
 -   repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 21.10b0
     hooks:
     - id: black
 
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.1.0
+    rev: 1.1.1
     hooks:
     - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==2.25.0]
+      additional_dependencies: [pyupgrade==2.29.0]
     - id: nbqa-isort
-      additional_dependencies: [isort==5.9.3]
+      additional_dependencies: [isort==5.10.0]
     - id: nbqa-black
-      additional_dependencies: [black==21.8b0]
+      additional_dependencies: [black==21.10b0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 -   repo: https://github.com/psf/black
     rev: 21.10b0
     hooks:
-    - id: black
+    - id: black-jupyter
 
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 1.1.1
@@ -33,5 +33,3 @@ repos:
       additional_dependencies: [pyupgrade==2.29.0]
     - id: nbqa-isort
       additional_dependencies: [isort==5.10.0]
-    - id: nbqa-black
-      additional_dependencies: [black==21.10b0]


### PR DESCRIPTION
```
* Update pre-commit hooks:
   - github.com/asottile/pyupgrade: 2.25.0 → 2.29.0
   - github.com/psf/black: 21.8b0 → 21.10b0
   - github.com/nbQA-dev/nbQA: 1.1.0 → 1.1.1
* Use black-jupyter hook
   - Allows for deprecation of nbqa-black hook from https://github.com/nbQA-dev/nbQA
```