### PR TITLE
feat: Update serialization and modifiers notebooks

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -2,8 +2,8 @@ name: Deploy Jupyter Book
 
 on:
   push:
-    branches:
-    - main
+    # branches:
+    # - main
   pull_request:
   workflow_dispatch:
 
@@ -31,7 +31,7 @@ jobs:
         jupyter-book build book/
 
     - name: Deploy Jupyter book to GitHub pages
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      # if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -2,8 +2,8 @@ name: Deploy Jupyter Book
 
 on:
   push:
-    # branches:
-    # - main
+    branches:
+    - main
   pull_request:
   workflow_dispatch:
 
@@ -36,7 +36,7 @@ jobs:
         jupyter-book build book/
 
     - name: Deploy Jupyter book to GitHub pages
-      # if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -18,9 +18,16 @@ jobs:
     - name: Get Conda and Python
       uses: "conda-incubator/setup-miniconda@v2"
       with:
-        auto-update-conda: true
         python-version: "3.9"
+        mamba-version: "*"
         channels: "conda-forge"
+        channel-priority: true
+
+    - name: Install ROOT
+      run: |
+        mamba env list
+        mamba install root
+        mamba list
 
     - name: Install Python dependencies
       run: |
@@ -28,16 +35,9 @@ jobs:
         python -m pip --no-cache-dir install -r binder/requirements.txt
         python -m pip --no-cache-dir install -r book/requirements.txt
 
-    - name: Install ROOT
-      run: |
-        conda env list
-        conda install root
-        conda list
-
-    - name: List dependencies
+    - name: List installed Python dependencies
       run: |
         python -m pip list
-        conda list
 
     - name: Build the book
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -11,23 +11,15 @@ jobs:
 
   deploy-book:
     runs-on: ubuntu-latest
+    container: atlasamglab/stats-base:root6.24.06
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Get Conda and Python
-      uses: "conda-incubator/setup-miniconda@v2"
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
       with:
-        python-version: "3.9"
-        mamba-version: "*"
-        channels: "conda-forge"
-        channel-priority: true
-
-    - name: Install ROOT
-      run: |
-        mamba env list
-        mamba install root
-        mamba list
+        python-version: 3.9
 
     - name: Install Python dependencies
       run: |
@@ -39,14 +31,8 @@ jobs:
       run: |
         python -m pip list
 
-    - name: List installed Conda packages
-      run: |
-        mamba env list
-        mamba list
-
     - name: Build the book
       run: |
-        mamba activate base
         jupyter-book build book/
 
     - name: Deploy Jupyter book to GitHub pages

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -35,9 +35,14 @@ jobs:
         python -m pip --no-cache-dir install -r binder/requirements.txt
         python -m pip --no-cache-dir install -r book/requirements.txt
 
-    - name: List installed Python dependencies
+    - name: List installed Python packages
       run: |
         python -m pip list
+
+    - name: List installed Conda packages
+      run: |
+        mamba env list
+        mamba list
 
     - name: Build the book
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -15,16 +15,29 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - name: Get Conda and Python
+      uses: "conda-incubator/setup-miniconda@v2"
       with:
-        python-version: 3.9
+        auto-update-conda: true
+        python-version: "3.9"
+        channels: "conda-forge"
 
-    - name: Install dependencies
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir install -r binder/requirements.txt
         python -m pip --no-cache-dir install -r book/requirements.txt
+
+    - name: Install ROOT
+      run: |
+        conda env list
+        conda install root
+        conda list
+
+    - name: List dependencies
+      run: |
+        python -m pip list
+        conda list
 
     - name: Build the book
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -46,6 +46,7 @@ jobs:
 
     - name: Build the book
       run: |
+        mamba activate base
         jupyter-book build book/
 
     - name: Deploy Jupyter book to GitHub pages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,13 @@ repos:
     hooks:
     - id: black-jupyter
 
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+    - id: codespell
+      files: ^.*\.(py|md|rst)$
+      args: ["-w", "-L", "hist,gaus"]
+
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 1.1.1
     hooks:

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Make ROOT available for comparisons and workspace use
+# c.f. https://github.com/conda-forge/root-feedstock
+conda config --add channels conda-forge
+conda config --set channel_priority strict
+
+conda install root

--- a/book/IntroToHiFa.ipynb
+++ b/book/IntroToHiFa.ipynb
@@ -347,7 +347,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Up to about 2 years ago, HistFactory was only implemented using ROOT, RooStats, RooFit (+ minuit). pyhf provides two separate pieces:\n",
+    "Up till 2018, HistFactory was only implemented using ROOT, RooStats, RooFit (+ minuit). pyhf provides two separate pieces:\n",
     "* a schema for serializing the HistFactory workspace in plain-text formats, such as JSON\n",
     "* a toolkit that interacts and manipulates the HistFactory workspaces\n",
     "\n",

--- a/book/Modifiers.ipynb
+++ b/book/Modifiers.ipynb
@@ -52,7 +52,11 @@
     "                        \"name\": \"signal\",\n",
     "                        \"data\": [5.0, 10.0],\n",
     "                        \"modifiers\": [\n",
-    "                            {\"name\": \"mynormfactor\", \"type\": \"normfactor\", \"data\": None}\n",
+    "                            {\n",
+    "                                \"name\": \"my_normfactor\",\n",
+    "                                \"type\": \"normfactor\",\n",
+    "                                \"data\": None,\n",
+    "                            }\n",
     "                        ],\n",
     "                    }\n",
     "                ],\n",
@@ -108,7 +112,7 @@
     "                        \"data\": [5.0, 10.0],\n",
     "                        \"modifiers\": [\n",
     "                            {\n",
-    "                                \"name\": \"mynormsys\",\n",
+    "                                \"name\": \"my_normsys\",\n",
     "                                \"type\": \"normsys\",\n",
     "                                \"data\": {\"hi\": 0.9, \"lo\": 1.1},\n",
     "                            }\n",
@@ -176,7 +180,7 @@
     "                        \"data\": [5.0, 10.0],\n",
     "                        \"modifiers\": [\n",
     "                            {\n",
-    "                                \"name\": \"myhistosys\",\n",
+    "                                \"name\": \"my_histosys\",\n",
     "                                \"type\": \"histosys\",\n",
     "                                \"data\": {\"hi_data\": [15, 22], \"lo_data\": [5, 18]},\n",
     "                            }\n",
@@ -241,7 +245,7 @@
     "                        \"name\": \"signal\",\n",
     "                        \"data\": [5.0, 10.0],\n",
     "                        \"modifiers\": [\n",
-    "                            {\"name\": \"myshapesys\", \"type\": \"shapesys\", \"data\": [1, 4]}\n",
+    "                            {\"name\": \"my_shapesys\", \"type\": \"shapesys\", \"data\": [1, 4]}\n",
     "                        ],\n",
     "                    }\n",
     "                ],\n",
@@ -277,7 +281,7 @@
    "source": [
     "### Example use case\n",
     "\n",
-    "A `shapesys` modifier could represent the Poisson statistical uncertainty of each bin in a sample."
+    "A `shapesys` modifier could represent the statistical uncertainty of each bin in a sample."
    ]
   },
   {
@@ -308,7 +312,7 @@
     "                        \"data\": [5.0, 10.0],\n",
     "                        \"modifiers\": [\n",
     "                            {\n",
-    "                                \"name\": \"mystaterror\",\n",
+    "                                \"name\": \"my_staterror\",\n",
     "                                \"type\": \"staterror\",\n",
     "                                \"data\": [1.0, 2.0],\n",
     "                            }\n",
@@ -440,7 +444,7 @@
     "                        \"data\": [5.0, 10.0],\n",
     "                        \"modifiers\": [\n",
     "                            {\n",
-    "                                \"name\": \"myshapefactor\",\n",
+    "                                \"name\": \"my_shapefactor\",\n",
     "                                \"type\": \"shapefactor\",\n",
     "                                \"data\": None,\n",
     "                            }\n",
@@ -483,7 +487,7 @@
     "\n",
     "Like in HistFactory, modifiers are controlled by parameters which are named based on the name you assign to the modifier. Therefore, as long as the modifiers you want to correlate are \"mostly\" compatible (e.g. same number of nuisance parameters allocated), you can correlate them!\n",
     "\n",
-    "Let's repeat the `normsys` example, and through in a `histosys` on top &mdash; both controlled by a single nuisance parameter."
+    "Let's repeat the `normsys` example, and add in a `histosys` uncertainty &mdash; both controlled by a **shared** single nuisance parameter."
    ]
   },
   {
@@ -503,12 +507,12 @@
     "                        \"data\": [5.0, 10.0],\n",
     "                        \"modifiers\": [\n",
     "                            {\n",
-    "                                \"name\": \"imshared\",\n",
+    "                                \"name\": \"shared_parameter\",\n",
     "                                \"type\": \"normsys\",\n",
     "                                \"data\": {\"hi\": 0.9, \"lo\": 1.1},\n",
     "                            },\n",
     "                            {\n",
-    "                                \"name\": \"imshared\",\n",
+    "                                \"name\": \"shared_parameter\",\n",
     "                                \"type\": \"histosys\",\n",
     "                                \"data\": {\"hi_data\": [15, 22], \"lo_data\": [5, 18]},\n",
     "                            },\n",
@@ -527,9 +531,11 @@
     "print(f\"        up: {model.expected_data([1.0])}\")\n",
     "\n",
     "\n",
-    "@widgets.interact(imshared=(-1, 1, 0.1))\n",
-    "def interact(imshared=0):\n",
-    "    print(f\"imshared = {imshared:4.1f}: {model.expected_data([imshared])}\")"
+    "@widgets.interact(shared_parameter=(-1, 1, 0.1))\n",
+    "def interact(shared_parameter=0):\n",
+    "    print(\n",
+    "        f\"shared_parameter = {shared_parameter:4.1f}: {model.expected_data([shared_parameter])}\"\n",
+    "    )"
    ]
   },
   {

--- a/book/Modifiers.ipynb
+++ b/book/Modifiers.ipynb
@@ -2,13 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Modifiers\n",
     "\n",
-    "In our simple examples so far, we've only used two types of modifiers, but HistFactory allows for a handful of modifiers that have proven to be sufficient to model a wide range of uncertainties.\n",
+    "In our simple examples so far, we've only used two types of modifiers, but HistFactory allows for a handful of modifiers that have proven to be sufficient to model a wide range of uncertainties. Each of the modifiers is further described in the [Modifiers section](https://pyhf.readthedocs.io/en/v0.6.3/likelihood.html#modifiers) of the pyhf docs on model specification.\n",
     "\n",
-    "We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.3/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
+    "There is an addtional table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.3/intro.html#id24) in the introduction of the pyhf documentation to use as reference.\n",
     "\n",
     "![modifiers and constraints](assets/modifiers_and_constraints.png)\n",
     "\n",
@@ -77,7 +79,7 @@
    "source": [
     "### Example use case\n",
     "\n",
-    "A `normfactor` modifier would be applied to scale the signal rate of a possible BSM signal or simultaneous in-situ measurements of background samples."
+    "A `normfactor` modifier could be applied to scale the signal rate of a possible BSM signal or simultaneous in-situ measurements of background samples."
    ]
   },
   {

--- a/book/Modifiers.ipynb
+++ b/book/Modifiers.ipynb
@@ -75,6 +75,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Example use case\n",
+    "\n",
+    "A `normfactor` modifier would be applied to scale the signal rate of a possible BSM signal or simultaneous in-situ measurements of background samples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Normalisation Uncertainty (normsys)\n",
     "\n",
     "This is a simple scaling of a sample, but constrained! Controlled by a single nuisance parameter."
@@ -126,6 +135,15 @@
    "metadata": {},
    "source": [
     "What do you think happens if we switch `\"hi\"` and `\"lo\"`?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example use case\n",
+    "\n",
+    "A `normsys` modifier is applied to every bin in a sample and represents the sample normalisation uncertainty. A `normsys` modifier could represent part of the uncertainty associated with a jet energy scale or a jet energy resolution."
    ]
   },
   {
@@ -191,6 +209,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Example use case\n",
+    "\n",
+    "A `histosys` modifier applies a correlated unceratinty with a per-bin modifier to a sample. The `hi_data` (`lo_data`) represent the expected event rates for upward (downward) variations for each bin of the sample. A `histosys` modifier could represent part of the uncertainty associated with a jet energy scale or a jet energy resolution."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Uncorrelated Shape (shapesys)\n",
     "\n",
     "A shape uncertainty, but fully **uncorrelated** across bins. Controlled by $n$ nuisance parameters (one for each bin)."
@@ -240,6 +267,15 @@
    "metadata": {},
    "source": [
     "Note the differences with `histosys`. Here, we specify the absolute uncertainty which is fed into the Poisson constraint. This tends to feel more like a bin-by-bin (bin-wise?) constrained `normfactor`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example use case\n",
+    "\n",
+    "A `shapesys` modifier is applied to each bin in a sample independntly and could represent the Poisson statistical uncertainty of each bin in a sample."
    ]
   },
   {
@@ -307,6 +343,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Example use case\n",
+    "\n",
+    "A `staterror` modifier is applied as a set of bin-wise scale factors to each sample and represent the inherent statistical uncertainty due to the finite sample size of Monte Carlo simulations of physics processes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Luminosity (lumi)\n",
     "\n",
     "A global scale factor that applies across channel and sample boundaries. Controlled by a single nuisance parameter."
@@ -354,6 +399,15 @@
     "@widgets.interact(lumi=(0, 10, 1))\n",
     "def interact(lumi=1):\n",
     "    print(f\"lumi = {lumi:2d}: {model.expected_data([lumi])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example use case\n",
+    "\n",
+    "A `lumi` modifier is applied as a global scale factor to all samples in a channel. Sample rates derived from theory calculations, as opposed to data-driven estimates, are scaled to the integrated luminosity corresponding to the observed data. A `lumi` modifier represents the uncertainty of luminosity measurement applied to the samples."
    ]
   },
   {
@@ -408,6 +462,15 @@
     "    print(\n",
     "        f\"staterror = ({shapefactor_0:2d}, {shapefactor_1:2d}): {model.expected_data([shapefactor_0, shapefactor_1])}\"\n",
     "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example use case\n",
+    "\n",
+    "A `shapefactor` modifier is applied as an unconstrained, bin-wise multipiciative factor and represents a data-driven estimation of sample rates. As an example, a `shapefactor` could represent a a scale factor applied to multijet backgrounds derived from measurements in data."
    ]
   },
   {
@@ -471,7 +534,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Isn't that nice? We're seeing the impact of a multiplicative bin-wise correlated shape modification convoluted with an additive normalization uncertainty &mdash; both constrained by a Gaussian."
+    "We're seeing the impact of a multiplicative bin-wise correlated shape modification convoluted with an additive normalization uncertainty &mdash; both constrained by a Gaussian."
    ]
   }
  ],

--- a/book/Modifiers.ipynb
+++ b/book/Modifiers.ipynb
@@ -88,7 +88,7 @@
    "source": [
     "## Normalisation Uncertainty (normsys)\n",
     "\n",
-    "This is a simple scaling of a sample, but constrained! Controlled by a single nuisance parameter."
+    "This is a simple constrained scaling of a sample representing the sample normalisation uncertainty, applied to every bin in the sample. Controlled by a single nuisance parameter."
    ]
   },
   {
@@ -145,7 +145,7 @@
    "source": [
     "### Example use case\n",
     "\n",
-    "A `normsys` modifier is applied to every bin in a sample and represents the sample normalisation uncertainty. A `normsys` modifier could represent part of the uncertainty associated with a jet energy scale or a jet energy resolution."
+    "A `normsys` modifier could represent part of the uncertainty associated with a jet energy scale or a jet energy resolution (which can contribute both a `normsys` and a `histosys` to a sample)."
    ]
   },
   {
@@ -154,7 +154,7 @@
    "source": [
     "## Correlated Shape (histosys)\n",
     "\n",
-    "A shape uncertainty, but fully correlated across bins. Controlled by a single nuisance parameter.\n",
+    "A `histosys` modifier applies a correlated per-bin shape unceratinty to a sample. The `hi_data` (`lo_data`) represent the expected event rates for upward (downward) variations for each bin of the sample. Controlled by a single nuisance parameter.\n",
     "\n",
     "Unlike most other modifiers, this is an additive effect."
    ]
@@ -213,7 +213,7 @@
    "source": [
     "### Example use case\n",
     "\n",
-    "A `histosys` modifier applies a correlated unceratinty with a per-bin modifier to a sample. The `hi_data` (`lo_data`) represent the expected event rates for upward (downward) variations for each bin of the sample. A `histosys` modifier could represent part of the uncertainty associated with a jet energy scale or a jet energy resolution."
+    "A `histosys` modifier could represent part of the uncertainty associated with a jet energy scale or a jet energy resolution (which can contribute both a `normsys` and a `histosys` to a sample)."
    ]
   },
   {
@@ -222,7 +222,7 @@
    "source": [
     "## Uncorrelated Shape (shapesys)\n",
     "\n",
-    "A shape uncertainty, but fully **uncorrelated** across bins. Controlled by $n$ nuisance parameters (one for each bin)."
+    "A shape uncertainty, but fully **uncorrelated** across bins (applied to each bin in a sample independently). Controlled by $n$ nuisance parameters (one for each bin)."
    ]
   },
   {
@@ -277,7 +277,7 @@
    "source": [
     "### Example use case\n",
     "\n",
-    "A `shapesys` modifier is applied to each bin in a sample independntly and could represent the Poisson statistical uncertainty of each bin in a sample."
+    "A `shapesys` modifier could represent the Poisson statistical uncertainty of each bin in a sample."
    ]
   },
   {
@@ -286,7 +286,7 @@
    "source": [
     "## MC Statistical Uncertainty (staterror)\n",
     "\n",
-    "Bin-wise scale factor. This is used to model the uncertainty in the bins due to Monte Carlo statistics. Controlled by $n$ nuisance parameters (one for each bin).\n",
+    "A `staterror` modifier is applied as a set of bin-wise scale factors to each sample. This is used to model the uncertainty in the bins due to Monte Carlo statistics. Controlled by $n$ nuisance parameters (one for each bin).\n",
     "\n",
     "In particular, this tends to be correlated across samples as they're usually modeled by the same MC generator. Unlike `shapesys` which is constrained by a Poisson, this modifier is constrained by a Gaussian."
    ]
@@ -347,7 +347,7 @@
    "source": [
     "### Example use case\n",
     "\n",
-    "A `staterror` modifier is applied as a set of bin-wise scale factors to each sample and represent the inherent statistical uncertainty due to the finite sample size of Monte Carlo simulations of physics processes."
+    "A `staterror` modifier represents the inherent statistical uncertainty due to the finite sample size of Monte Carlo simulations of physics processes."
    ]
   },
   {
@@ -356,7 +356,7 @@
    "source": [
     "## Luminosity (lumi)\n",
     "\n",
-    "A global scale factor that applies across channel and sample boundaries. Controlled by a single nuisance parameter."
+    "A `lumi` modifier is applied as a global scale factor across all samples in a channel and sample boundaries. Sample rates derived from theory calculations, as opposed to data-driven estimates (`shapefactor`), are scaled to the integrated luminosity corresponding to the observed data. Controlled by a single nuisance parameter."
    ]
   },
   {
@@ -409,7 +409,7 @@
    "source": [
     "### Example use case\n",
     "\n",
-    "A `lumi` modifier is applied as a global scale factor to all samples in a channel. Sample rates derived from theory calculations, as opposed to data-driven estimates, are scaled to the integrated luminosity corresponding to the observed data. A `lumi` modifier represents the uncertainty of luminosity measurement applied to the samples."
+    "A `lumi` modifier represents the uncertainty of luminosity measurement applied to the samples."
    ]
   },
   {
@@ -418,7 +418,7 @@
    "source": [
     "## Data-driven Shape (shapefactor)\n",
     "\n",
-    "Bin-wise multiplicative parameters to support data-driven estimation of sample rates (e.g. think of estimating multi-jet backgrounds). Controlled by $n$ nuisance parameters (one for each bin).\n",
+    "A `shapefactor` modifier is applied as an unconstrained, bin-wise multipiciative factor and represents a data-driven estimation of sample rates (e.g. think of estimating multi-jet backgrounds). Controlled by $n$ nuisance parameters (one for each bin).\n",
     "\n",
     "This feels like a bin-wise `normfactor`."
    ]
@@ -472,7 +472,7 @@
    "source": [
     "### Example use case\n",
     "\n",
-    "A `shapefactor` modifier is applied as an unconstrained, bin-wise multipiciative factor and represents a data-driven estimation of sample rates. As an example, a `shapefactor` could represent a a scale factor applied to multijet backgrounds derived from measurements in data."
+    "A `shapefactor` modifier could represent a scale factor applied to multijet backgrounds derived from measurements in data."
    ]
   },
   {

--- a/book/SerializationAndPatching.ipynb
+++ b/book/SerializationAndPatching.ipynb
@@ -363,7 +363,7 @@
    "source": [
     "We've made our models. Let's test hypotheses!\n",
     "\n",
-    "*Note: this will not be as instantaneous as our simple models.. but it should still be pretty fast!*"
+    "*Note: this will not be as instantaneous as our simple models...but it should still be pretty fast!*"
    ]
   },
   {
@@ -380,9 +380,9 @@
     "    test_stat=\"qtilde\",\n",
     "    return_expected_set=True,\n",
     ")\n",
-    "print(\n",
-    "    f\"Observed: {result_below[0]}, Expected band: {[exp.tolist() for exp in result_below[1]]}\"\n",
-    ")"
+    "\n",
+    "print(f\"Observed CLs: {result_below[0]}\")\n",
+    "print(f\"Expected CLs band: {[exp.tolist() for exp in result_below[1]]}\")"
    ]
   },
   {
@@ -398,9 +398,9 @@
     "    test_stat=\"qtilde\",\n",
     "    return_expected_set=True,\n",
     ")\n",
-    "print(\n",
-    "    f\"Observed: {result_above[0]}, Expected band: {[exp.tolist() for exp in result_above[1]]}\"\n",
-    ")"
+    "\n",
+    "print(f\"Observed CLs: {result_above[0]}\")\n",
+    "print(f\"Expected CLs band: {[exp.tolist() for exp in result_above[1]]}\")"
    ]
   },
   {

--- a/book/SerializationAndPatching.ipynb
+++ b/book/SerializationAndPatching.ipynb
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As of this tutorial, ATLAS has [published 8 full statistical models to HEPData](https://pyhf.readthedocs.io/en/v0.6.3/citations.html#published-statistical-models)\n",
+    "As of this tutorial, ATLAS has [published 18 full statistical models to HEPData](https://scikit-hep.org/pyhf/citations.html#published-statistical-models)\n",
     "\n",
     "<p align=\"center\">\n",
     "<a href=\"https://www.hepdata.net/record/ins1755298?version=3\"><img src=\"https://raw.githubusercontent.com/matthewfeickert/talk-SciPy-2020/e0c509cd0dfef98f5876071edd4c60aff9199a1b/figures/HEPData_likelihoods.png\"></a>\n",

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -108,8 +108,24 @@
     "Printing XML Files for channel: channel2\n",
     "Finished printing XML files\n",
     "Finished printing XML files\n",
-    "```\n",
-    "\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
+    "  printf 'int printXML(){\\nTFile* myfile = TFile::Open(\"results/example_combined_GaussExample_model.root\");\\nmyfile->Get<RooStats::HistFactory::Measurement>(\"GaussExample\")->PrintXML();\\nreturn 0;\\n}\\n' > printXML.C && \\\n",
+    "  root -l -b -q printXML.C"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "which dumps them into the same directory you ran from:"
    ]
   },

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -27,8 +27,20 @@
    "outputs": [],
    "source": [
     "# Need to be in the directory containing config directory\n",
-    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
-    "  hist2workspace config/example.xml"
+    "from os import chdir\n",
+    "from pathlib import Path\n",
+    "\n",
+    "_top_level_dir = Path.cwd()\n",
+    "chdir(_top_level_dir.joinpath(\"data\", \"multichannel_histfactory\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! hist2workspace config/example.xml"
    ]
   },
   {
@@ -59,9 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Using IPython shell magics need to change directory each time\n",
-    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
-    "  ls -lhF results/"
+    "! ls -lhF results/"
    ]
   },
   {
@@ -117,9 +127,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
-    "  printf 'int printXML(){\\nTFile* _file0 = TFile::Open(\"results/example_combined_GaussExample_model.root\");\\n_file0->Get<RooStats::HistFactory::Measurement>(\"GaussExample\")->PrintXML();\\nreturn 0;\\n}\\n' > printXML.C && \\\n",
-    "  root -l -b -q printXML.C"
+    "import ROOT\n",
+    "\n",
+    "_file0 = ROOT.TFile.Open(\"results/example_combined_GaussExample_model.root\")\n",
+    "_file0.GaussExample.PrintXML()"
    ]
   },
   {
@@ -151,8 +162,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
-    "  ls -lhF"
+    "! ls -lhF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chdir(_top_level_dir)"
    ]
   },
   {

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -122,6 +122,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To do this programatically, you can either write a `ROOT` macro\n",
+    "\n",
+    "```C++\n",
+    "// printXML.C\n",
+    "int printXML() {\n",
+    "    TFile* _file0 = TFile::Open(\"results/example_combined_GaussExample_model.root\");\n",
+    "    _file0->Get<RooStats::HistFactory::Measurement>(\"GaussExample\")->PrintXML();\n",
+    "\n",
+    "    return 0;\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "and run it\n",
+    "\n",
+    "```console\n",
+    "$ root -l -b -q printXML.C\n",
+    "```\n",
+    "\n",
+    "but we can also do the same with PyROOT in as many lines"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -118,7 +118,7 @@
    "outputs": [],
    "source": [
     "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
-    "  printf 'int printXML(){\\nTFile* myfile = TFile::Open(\"results/example_combined_GaussExample_model.root\");\\nmyfile->Get<RooStats::HistFactory::Measurement>(\"GaussExample\")->PrintXML();\\nreturn 0;\\n}\\n' > printXML.C && \\\n",
+    "  printf 'int printXML(){\\nTFile* _file0 = TFile::Open(\"results/example_combined_GaussExample_model.root\");\\n_file0->Get<RooStats::HistFactory::Measurement>(\"GaussExample\")->PrintXML();\\nreturn 0;\\n}\\n' > printXML.C && \\\n",
     "  root -l -b -q printXML.C"
    ]
   },

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## Getting the XML+ROOT\n",
     "\n",
-    "Note, getting the XML+ROOT won't necessarily be covered as part of the tutorial.\n",
+    "Note, getting the XML+ROOT won't necessarily be covered as part of the tutorial as it requires ROOT (though ROOT is installed in the Binder instance).\n",
     "\n",
     "If you want to practice extracting out the HistFactory files from the workspace, first create the workspace like so:"
    ]
@@ -78,7 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In particular, `example_combined_GaussExample_model.root` is exactly the file that contains the `RooStats::HistFactory::Measurement` object:\n",
+    "In particular, `example_combined_GaussExample_model.root` is the file that contains the `RooStats::HistFactory::Measurement` object:\n",
     "\n",
     "```\n",
     "$ root results/example_combined_GaussExample_model.root \n",

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -6,8 +6,13 @@
    "source": [
     "# Workspace Manipulations\n",
     "\n",
-    "In this chapter, you will learn about various workspace manipulations including how to convert from HistFactory XML+ROOT workspaces to pyhf. We'll cover some common pitfalls such as locations of root files, and being able to set the base path for the conversion.\n",
-    "\n",
+    "In this chapter, you will learn about various workspace manipulations including how to convert from HistFactory XML+ROOT workspaces to pyhf. We'll cover some common pitfalls such as locations of root files, and being able to set the base path for the conversion."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Getting the XML+ROOT\n",
     "\n",
     "Note, getting the XML+ROOT won't necessarily be covered as part of the tutorial.\n",
@@ -15,25 +20,34 @@
     "If you want to practice extracting out the HistFactory files from the workspace, first create the workspace like so:\n",
     "\n",
     "```\n",
+    "$ cd $(dirname $(dirname $(find . -name \"example.xml\")))  # Reach the directory containing config\n",
     "$ hist2workspace config/example.xml\n",
     "\n",
     "... lots of output! ...\n",
-    "```\n",
-    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "and you'll notice a few new files being made!\n",
     "\n",
     "```\n",
-    "$ ls results/\n",
+    "$ ls -lh results/\n",
     "total 136K\n",
-    "drwxr-xr-x 7 kratsg 224 Sep 23 16:32 ./\n",
-    "drwxr-xr-x 5 kratsg 160 Sep 23 16:33 ../\n",
     "-rw-r--r-- 1 kratsg 503 Sep 23 16:32 example_GaussExample.root\n",
     "-rw-r--r-- 1 kratsg 40K Sep 23 16:32 example_channel1_GaussExample_model.root\n",
     "-rw-r--r-- 1 kratsg 38K Sep 23 16:32 example_channel2_GaussExample_model.root\n",
     "-rw-r--r-- 1 kratsg 48K Sep 23 16:32 example_combined_GaussExample_model.root\n",
     "-rw-r--r-- 1 kratsg  26 Sep 23 16:32 example_results.table\n",
-    "```\n",
-    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "In particular, `example_combined_GaussExample_model.root` is exactly the file that contains the `RooStats::HistFactory::Measurement` object:\n",
     "\n",
     "```\n",
@@ -79,10 +93,8 @@
     "which dumps them into the same directory you ran from:\n",
     "\n",
     "```\n",
-    "$ ls\n",
+    "$ ls -lh\n",
     "total 12K\n",
-    "drwxr-xr-x 8 kratsg  256 Sep 23 16:32 ./\n",
-    "drwxr-xr-x 4 kratsg  128 Sep 22 15:10 ../\n",
     "-rw-r--r-- 1 kratsg  459 Sep 23 16:32 GaussExample.xml\n",
     "-rw-r--r-- 1 kratsg 1.1K Sep 23 16:32 GaussExample_channel1.xml\n",
     "-rw-r--r-- 1 kratsg  795 Sep 23 16:32 GaussExample_channel2.xml\n",

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -17,22 +17,39 @@
     "\n",
     "Note, getting the XML+ROOT won't necessarily be covered as part of the tutorial.\n",
     "\n",
-    "If you want to practice extracting out the HistFactory files from the workspace, first create the workspace like so:\n",
-    "\n",
-    "```\n",
-    "$ cd $(dirname $(dirname $(find . -name \"example.xml\")))  # Reach the directory containing config directory\n",
-    "$ hist2workspace config/example.xml\n",
-    "\n",
-    "... lots of output! ...\n",
-    "```"
+    "If you want to practice extracting out the HistFactory files from the workspace, first create the workspace like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! cd $(dirname $(dirname $(find . -name \"example.xml\")))  # Reach the directory containing config directory\n",
+    "! hist2workspace config/example.xml"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and you'll notice a few new files being made!\n",
-    "\n",
+    "and you'll notice a few new files being made!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! ls -lh results/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "```\n",
     "$ ls -lh results/\n",
     "total 136K\n",
@@ -90,8 +107,22 @@
     "Finished printing XML files\n",
     "```\n",
     "\n",
-    "which dumps them into the same directory you ran from:\n",
-    "\n",
+    "which dumps them into the same directory you ran from:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! ls -lh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "```\n",
     "$ ls -lh\n",
     "total 12K\n",
@@ -101,8 +132,13 @@
     "drwxr-xr-x 6 kratsg  192 Sep 22 15:10 config/\n",
     "drwxr-xr-x 3 kratsg   96 Sep 22 15:10 data/\n",
     "drwxr-xr-x 7 kratsg  224 Sep 23 16:32 results/\n",
-    "```\n",
-    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## XML to JSON\n",
     "\n",
     "### via the command line\n",

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -20,7 +20,7 @@
     "If you want to practice extracting out the HistFactory files from the workspace, first create the workspace like so:\n",
     "\n",
     "```\n",
-    "$ cd $(dirname $(dirname $(find . -name \"example.xml\")))  # Reach the directory containing config\n",
+    "$ cd $(dirname $(dirname $(find . -name \"example.xml\")))  # Reach the directory containing config directory\n",
     "$ hist2workspace config/example.xml\n",
     "\n",
     "... lots of output! ...\n",

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -44,6 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Using IPython shell magics need to change directory each time\n",
     "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
     "  ls -lh results/"
    ]
@@ -155,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pyhf --help"
+    "! pyhf --help"
    ]
   },
   {
@@ -177,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pyhf xml2json --help"
+    "! pyhf xml2json --help"
    ]
   },
   {
@@ -193,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!tail -n +15 data/multichannel_histfactory/config/example.xml | cat -n"
+    "! tail -n +15 data/multichannel_histfactory/config/example.xml | cat -n"
    ]
   },
   {
@@ -214,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pyhf xml2json --basedir data/multichannel_histfactory data/multichannel_histfactory/config/example.xml --hide-progress | cat -n"
+    "! pyhf xml2json --basedir data/multichannel_histfactory data/multichannel_histfactory/config/example.xml --hide-progress | cat -n"
    ]
   },
   {
@@ -436,7 +437,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pyhf prune --help"
+    "! pyhf prune --help"
    ]
   },
   {

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "# Using IPython shell magics need to change directory each time\n",
     "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
-    "  ls -lh results/"
+    "  ls -lhF results/"
    ]
   },
   {
@@ -136,7 +136,7 @@
    "outputs": [],
    "source": [
     "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
-    "  ls -lh"
+    "  ls -lhF"
    ]
   },
   {

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -39,6 +39,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "$ ls -lhF results/\n",
+    "total 136K\n",
+    "-rw-r--r-- 1 kratsg 503 Sep 23 16:32 example_GaussExample.root\n",
+    "-rw-r--r-- 1 kratsg 40K Sep 23 16:32 example_channel1_GaussExample_model.root\n",
+    "-rw-r--r-- 1 kratsg 38K Sep 23 16:32 example_channel2_GaussExample_model.root\n",
+    "-rw-r--r-- 1 kratsg 48K Sep 23 16:32 example_combined_GaussExample_model.root\n",
+    "-rw-r--r-- 1 kratsg  26 Sep 23 16:32 example_results.table\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -47,21 +62,6 @@
     "# Using IPython shell magics need to change directory each time\n",
     "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
     "  ls -lhF results/"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "$ ls -lh results/\n",
-    "total 136K\n",
-    "-rw-r--r-- 1 kratsg 503 Sep 23 16:32 example_GaussExample.root\n",
-    "-rw-r--r-- 1 kratsg 40K Sep 23 16:32 example_channel1_GaussExample_model.root\n",
-    "-rw-r--r-- 1 kratsg 38K Sep 23 16:32 example_channel2_GaussExample_model.root\n",
-    "-rw-r--r-- 1 kratsg 48K Sep 23 16:32 example_combined_GaussExample_model.root\n",
-    "-rw-r--r-- 1 kratsg  26 Sep 23 16:32 example_results.table\n",
-    "```"
    ]
   },
   {
@@ -130,21 +130,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
-    "  ls -lhF"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "```\n",
-    "$ ls -lh\n",
+    "$ ls -lhF\n",
     "total 12K\n",
     "-rw-r--r-- 1 kratsg  459 Sep 23 16:32 GaussExample.xml\n",
     "-rw-r--r-- 1 kratsg 1.1K Sep 23 16:32 GaussExample_channel1.xml\n",
@@ -153,6 +143,16 @@
     "drwxr-xr-x 3 kratsg   96 Sep 22 15:10 data/\n",
     "drwxr-xr-x 7 kratsg  224 Sep 23 16:32 results/\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
+    "  ls -lhF"
    ]
   },
   {

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -57,11 +57,11 @@
     "```\n",
     "$ ls -lhF results/\n",
     "total 136K\n",
-    "-rw-r--r-- 1 kratsg 503 Sep 23 16:32 example_GaussExample.root\n",
-    "-rw-r--r-- 1 kratsg 40K Sep 23 16:32 example_channel1_GaussExample_model.root\n",
-    "-rw-r--r-- 1 kratsg 38K Sep 23 16:32 example_channel2_GaussExample_model.root\n",
-    "-rw-r--r-- 1 kratsg 48K Sep 23 16:32 example_combined_GaussExample_model.root\n",
-    "-rw-r--r-- 1 kratsg  26 Sep 23 16:32 example_results.table\n",
+    "-rw-r--r-- 1 jovyan jovyan 40K Nov  8 21:01 example_channel1_GaussExample_model.root\n",
+    "-rw-r--r-- 1 jovyan jovyan 38K Nov  8 21:01 example_channel2_GaussExample_model.root\n",
+    "-rw-r--r-- 1 jovyan jovyan 47K Nov  8 21:01 example_combined_GaussExample_model.root\n",
+    "-rw-r--r-- 1 jovyan jovyan 503 Nov  8 21:01 example_GaussExample.root\n",
+    "-rw-r--r-- 1 jovyan jovyan  26 Nov  8 21:01 example_results.table\n",
     "```"
    ]
   },
@@ -171,13 +171,13 @@
    "source": [
     "```\n",
     "$ ls -lhF\n",
-    "total 12K\n",
-    "-rw-r--r-- 1 kratsg  459 Sep 23 16:32 GaussExample.xml\n",
-    "-rw-r--r-- 1 kratsg 1.1K Sep 23 16:32 GaussExample_channel1.xml\n",
-    "-rw-r--r-- 1 kratsg  795 Sep 23 16:32 GaussExample_channel2.xml\n",
-    "drwxr-xr-x 6 kratsg  192 Sep 22 15:10 config/\n",
-    "drwxr-xr-x 3 kratsg   96 Sep 22 15:10 data/\n",
-    "drwxr-xr-x 7 kratsg  224 Sep 23 16:32 results/\n",
+    "total 24K\n",
+    "drwxr-xr-x 2 jovyan jovyan 4.0K Nov  8 19:52 config/\n",
+    "drwxr-xr-x 2 jovyan jovyan 4.0K Nov  8 19:52 data/\n",
+    "-rw-r--r-- 1 jovyan jovyan 1.1K Nov  8 21:01 GaussExample_channel1.xml\n",
+    "-rw-r--r-- 1 jovyan jovyan  794 Nov  8 21:01 GaussExample_channel2.xml\n",
+    "-rw-r--r-- 1 jovyan jovyan  459 Nov  8 21:01 GaussExample.xml\n",
+    "drwxr-xr-x 2 jovyan jovyan 4.0K Nov  8 21:01 results/\n",
     "```"
    ]
   },

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -26,8 +26,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! cd $(dirname $(dirname $(find . -name \"example.xml\")))  # Reach the directory containing config directory\n",
-    "! hist2workspace config/example.xml"
+    "# Need to be in the directory containing config directory\n",
+    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
+    "  hist2workspace config/example.xml"
    ]
   },
   {
@@ -43,7 +44,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! ls -lh results/"
+    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
+    "  ls -lh results/"
    ]
   },
   {
@@ -116,7 +118,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! ls -lh"
+    "! cd $(dirname $(dirname $(find . -name \"example.xml\"))) && \\\n",
+    "  ls -lh"
    ]
   },
   {


### PR DESCRIPTION
Update serialization and modifiers notebooks for [Publication of statistical models: hands-on workshop](https://indico.cern.ch/event/1088121/overview) pyhf session.

```
* Add Binder postBuild configuration file to install ROOT in Binder environment from Conda-forge
   - Note this slows down the Binder build significantly as Conda is very slow to install ROOT
* Run CI in atlasamglab/stats-base:root6.24.06 Docker container to provide ROOT for serialization notebook
* Add ROOT execution to examples in WorkspaceManipulations notebook
* Add example use cases to all modifiers in Modifiers notebook
* Update number of published probability models to 18
* Add codespell pre-commit hook
```