### PR TITLE
chore: Update to Jupyter Book v0.12.1

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -1,25 +1,26 @@
 # https://jupyterbook.org/customize/toc.html
-- file: introduction
-
-- part: Get started
+format: jb-book
+root: introduction
+parts:
+- caption: Get started
   chapters:
   - file: HelloWorld
   - file: SimpleWorkspace
   - file: SerializationAndPatching
 
-- part: Common use and applications
+- caption: Common use and applications
   chapters:
-    - file: PullPlot
-    - file: Toys
-    - file: Combinations
+  - file: PullPlot
+  - file: Toys
+  - file: Combinations
 
-- part: More Information
+- caption: More Information
   chapters:
-    - file: IntroToHiFa
-    - file: WorkspaceManipulations
-    - file: Modifiers
-    - file: UsingCalculators
+  - file: IntroToHiFa
+  - file: WorkspaceManipulations
+  - file: Modifiers
+  - file: UsingCalculators
 
-- part: Learn Fundamentals
+- caption: Learn Fundamentals
   chapters:
   - file: InterpolationCodes

--- a/book/requirements.txt
+++ b/book/requirements.txt
@@ -1,1 +1,1 @@
-jupyter-book==0.10.2
+jupyter-book==0.12.1


### PR DESCRIPTION
```
* Update to Jupyter Book v0.12.1
* Migrate _toc.yml to use Jupyter Book v0.11+ syntax
   - c.f. https://executablebooks.org/en/latest/updates/2021-06-18-update-toc.html
```