### PR TITLE
feat: Use mamba for installing packages from conda-forge

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -7,4 +7,5 @@ set -e
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 
+# Use mamba to speed up install
 conda install root

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -8,4 +8,4 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 
 # Use mamba to speed up install
-conda install root
+mamba install root


### PR DESCRIPTION
Significantly speed up installation of ROOT from conda-forge by using `mamba`. As [Binder already uses `mamba` for `repo2docker`](https://github.com/jupyterhub/repo2docker/pull/962) there is nothing extra to install. :) Thanks to @chrisburr for the advice here!

```
* Use mamba over conda for installation of ROOT in Binder postBuild
   - Significantly improves speed of package solve and install
```