### PR TITLE
ci: Deploy Jupyter Book on workflow dispatch events

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -36,7 +36,7 @@ jobs:
         jupyter-book build book/
 
     - name: Deploy Jupyter book to GitHub pages
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -36,6 +36,7 @@ jobs:
         jupyter-book build book/
 
     - name: Deploy Jupyter book to GitHub pages
+      # Deploy either on push events (merged PRs) or workflow dispatch triggers
       if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
Resolves #19 

```
* Deploy the Jupyter Book to either on push events (coming from merged PRs)
or from workflow dispatch triggers (to allow for redeployment on demand).
```