### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
     - id: codespell
       files: ^.*\.(py|md|rst)$
-      args: ["--write-changes", "--ignore-words", "hist,gaus"]
+      args: ["--write-changes", "--ignore-words-list", "hist,gaus"]
 
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 1.3.1


### PR DESCRIPTION
* Update pre-commit hooks:
   - github.com/pre-commit/pre-commit-hooks: v4.0.1 → v4.2.0
   - github.com/asottile/pyupgrade: v2.29.0 → v2.32.0
   - github.com/psf/black: v21.10b0 → v22.3.0
   - github.com/nbQA-dev/nbQA: v1.1.1 → v1.3.1
* Use full option names for codespell

```
* Update pre-commit hooks:
   - github.com/pre-commit/pre-commit-hooks: v4.0.1 → v4.2.0
   - github.com/asottile/pyupgrade: v2.29.0 → v2.32.0
   - github.com/psf/black: v21.10b0 → v22.3.0
   - github.com/nbQA-dev/nbQA: v1.1.1 → v1.3.1
* Use full option names for codespell
```