### PR TITLE
ci: Add pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+  autoupdate_commit_msg: "chore: [pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: quarterly
+
 repos:
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Tutorial last given at the [April 2021 PyHEP topical meeting](https://indico.cer
 
 **The tutorial is based off of [`pyhf` `v0.6.3`](https://pypi.org/project/pyhf/0.6.3/)**
 
-[![Deploy Jupyter Book](https://github.com/pyhf/pyhf-tutorial/workflows/Deploy%20Jupyter%20Book/badge.svg?branch=main)](https://pyhf.github.io/pyhf-tutorial/)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyhf/pyhf-tutorial/main?urlpath=lab)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4670321.svg)](https://doi.org/10.5281/zenodo.4670321)
+
+[![Deploy Jupyter Book](https://github.com/pyhf/pyhf-tutorial/workflows/Deploy%20Jupyter%20Book/badge.svg?branch=main)](https://pyhf.github.io/pyhf-tutorial/)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pyhf/pyhf-tutorial/main.svg)](https://results.pre-commit.ci/latest/github/pyhf/pyhf-tutorial/main)
 
 ## Setup
 


### PR DESCRIPTION
```
* Add pre-commit.ci with pre-commit hook updates on a quarterly basis.
* Add pre-commit.ci status badge to README.
```

[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pyhf/pyhf-tutorial/main.svg)](https://results.pre-commit.ci/latest/github/pyhf/pyhf-tutorial/main)