### PR TITLE
chore: Update GitHub Actions to latest releases

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: '3.9'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v3
       with:
-        python-version: '3.10'
+        python-version: '3.9'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: [ '3.9' ]
+        python-version: '3.10'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: [ '3.9' ]
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -14,7 +14,7 @@ jobs:
     container: atlasamglab/stats-base:root6.24.06
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v2

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [ '3.9' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1


### PR DESCRIPTION
```
* Update checkout action to v3
* Update setup-python to v3
   - skipping v4 for 'Deploy Jupyter Book' for now given regression with containers

Co-authored-by: Matthew Feickert <matthew.feickert@cern.ch>
```