### PR TITLE
fix: Add '--yes' flag to mamba install

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -8,4 +8,4 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 
 # Use mamba to speed up install
-mamba install root
+mamba install --yes root


### PR DESCRIPTION
Without the `--yes` flag the mamba install will hang waiting for user input.