### PR TITLE
feat: Bump to 0.7.0 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tutorial last given at the [April 2021 PyHEP topical meeting](https://indico.cern.ch/event/985425/).
 
-**The tutorial is based off of [`pyhf` `v0.6.3`](https://pypi.org/project/pyhf/0.6.3/)**
+**The tutorial is based off of [`pyhf` `v0.7.0`](https://pypi.org/project/pyhf/0.7.0/)**
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyhf/pyhf-tutorial/main?urlpath=lab)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4670321.svg)](https://doi.org/10.5281/zenodo.4670321)

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-pyhf[xmlio,minuit,contrib]==0.6.3
+pyhf[xmlio,minuit,contrib]==0.7.0
 # visualization
 ipywidgets~=7.5
 pandas~=1.0

--- a/book/HelloWorld.ipynb
+++ b/book/HelloWorld.ipynb
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What did we just make? This returns a [`pyhf.pdf.Model`](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.pdf.Model.html#pyhf.pdf.Model) object. Let's check out the specification."
+    "What did we just make? This returns a [`pyhf.pdf.Model`](https://pyhf.readthedocs.io/en/v0.7.0/_generated/pyhf.pdf.Model.html#pyhf.pdf.Model) object. Let's check out the specification."
    ]
   },
   {
@@ -144,7 +144,7 @@
     "\n",
     "where $n = \\{n_1, n_2\\}$ for a 2-bin model (we're being slightly fast and loose with our mathematical notation here), and similarly for $s$, $b$, and $\\gamma$.\n",
     "\n",
-    "The 'shapesys' is defined in the [HistFactory paper](https://cds.cern.ch/record/1456844)... however, it can be a little hard to extract out the necessary information. We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.3/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
+    "The 'shapesys' is defined in the [HistFactory paper](https://cds.cern.ch/record/1456844)... however, it can be a little hard to extract out the necessary information. We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.7.0/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
     "\n",
     "![modifiers and constraints](assets/modifiers_and_constraints.png)"
    ]
@@ -515,7 +515,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're not performing inference just yet. We're simply computing the 'logpdf' of the model specified by the parameters $\\theta$ against the provided data. To perform a fit, we use the [inference API](https://pyhf.readthedocs.io/en/v0.6.3/api.html#inference) via `pyhf.infer`.\n",
+    "We're not performing inference just yet. We're simply computing the 'logpdf' of the model specified by the parameters $\\theta$ against the provided data. To perform a fit, we use the [inference API](https://pyhf.readthedocs.io/en/v0.7.0/api.html#inference) via `pyhf.infer`.\n",
     "\n",
     "When fitting a model to data, we usually want to find the $\\hat{\\theta}$ which refers to the \"Maximum Likelihood Estimate\" of the model parameters. This is often referred to mathematically by\n",
     "\n",
@@ -675,7 +675,7 @@
    "source": [
     "## Simple Upper Limit\n",
     "\n",
-    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upperlimit` API](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.infer.intervals.upperlimit.html), which also can calculate the upper limit by interpolating"
+    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upperlimit` API](https://pyhf.readthedocs.io/en/v0.7.0/_generated/pyhf.infer.intervals.upperlimit.html), which also can calculate the upper limit by interpolating"
    ]
   },
   {

--- a/book/HelloWorld.ipynb
+++ b/book/HelloWorld.ipynb
@@ -675,7 +675,7 @@
    "source": [
     "## Simple Upper Limit\n",
     "\n",
-    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upperlimit` API](https://pyhf.readthedocs.io/en/v0.7.0/_generated/pyhf.infer.intervals.upperlimit.html), which also can calculate the upper limit by interpolating"
+    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upper_limits.upper_limit` API](https://pyhf.readthedocs.io/en/v0.7.0/_generated/pyhf.infer.intervals.upper_limits.upper_limit.html#pyhf.infer.intervals.upper_limits.upper_limit), which also can calculate the upper limit by interpolating"
    ]
   },
   {
@@ -687,7 +687,7 @@
    "outputs": [],
    "source": [
     "poi_values = np.linspace(0.1, 5, 50)\n",
-    "obs_limit, exp_limits, (scan, results) = pyhf.infer.intervals.upperlimit(\n",
+    "obs_limit, exp_limits, (scan, results) = pyhf.infer.intervals.upper_limits.upper_limit(\n",
     "    observations, model, poi_values, level=0.05, return_results=True\n",
     ")\n",
     "print(f\"Upper limit (obs): μ = {obs_limit:.4f}\")\n",
@@ -720,7 +720,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that if you wanted to do all of this \"by hand\" you still could pretty easily. The `pyhf.infer.intervals.upperlimit` API just makes it easier."
+    "Note that if you wanted to do all of this \"by hand\" you still could pretty easily. The `pyhf.infer.intervals.upper_limits.upper_limit` API just makes it easier."
    ]
   },
   {

--- a/book/Modifiers.ipynb
+++ b/book/Modifiers.ipynb
@@ -8,9 +8,9 @@
    "source": [
     "# Modifiers\n",
     "\n",
-    "In our simple examples so far, we've only used two types of modifiers, but HistFactory allows for a handful of modifiers that have proven to be sufficient to model a wide range of uncertainties. Each of the modifiers is further described in the [Modifiers section](https://pyhf.readthedocs.io/en/v0.6.3/likelihood.html#modifiers) of the pyhf docs on model specification.\n",
+    "In our simple examples so far, we've only used two types of modifiers, but HistFactory allows for a handful of modifiers that have proven to be sufficient to model a wide range of uncertainties. Each of the modifiers is further described in the [Modifiers section](https://pyhf.readthedocs.io/en/v0.7.0/likelihood.html#modifiers) of the pyhf docs on model specification.\n",
     "\n",
-    "There is an addtional table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.6.3/intro.html#id24) in the introduction of the pyhf documentation to use as reference.\n",
+    "There is an addtional table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.7.0/intro.html#id24) in the introduction of the pyhf documentation to use as reference.\n",
     "\n",
     "![modifiers and constraints](assets/modifiers_and_constraints.png)\n",
     "\n",

--- a/book/SerializationAndPatching.ipynb
+++ b/book/SerializationAndPatching.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "## Patching in Signals\n",
     "\n",
-    "Let's look at this [`pyhf.PatchSet`](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.patchset.PatchSet.html#pyhf.patchset.PatchSet) object which provides a user-friendly way to interact with many signal patches at once.\n",
+    "Let's look at this [`pyhf.PatchSet`](https://pyhf.readthedocs.io/en/v0.7.0/_generated/pyhf.patchset.PatchSet.html#pyhf.patchset.PatchSet) object which provides a user-friendly way to interact with many signal patches at once.\n",
     "\n",
     "### PatchSet"
    ]

--- a/book/SimpleWorkspace.ipynb
+++ b/book/SimpleWorkspace.ipynb
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What did we just make? This returns a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object. Let's check out the specification."
+    "What did we just make? This returns a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.7.0/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object. Let's check out the specification."
    ]
   },
   {
@@ -158,7 +158,7 @@
    "source": [
     "What does this mean for us though? Well, when we ask for a model, we specify the measurement that we want to use with it. Each of these measurements above have no additional parameter configurations on top of the existing model specification. Additionally, they all declare that the parameter of interest is `mu`.\n",
     "\n",
-    "See the [documentation](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace.model) for more information. In this case, let's build the model for the default measurement."
+    "See the [documentation](https://pyhf.readthedocs.io/en/v0.7.0/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace.model) for more information. In this case, let's build the model for the default measurement."
    ]
   },
   {

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -207,7 +207,7 @@
     "\n",
     "### via the command line\n",
     "\n",
-    "So pyhf comes with a lot of nifty utilities you can access. The documentation for the command line can be found via `pyhf --help` or [online](https://pyhf.readthedocs.io/en/v0.6.3/cli.html)."
+    "So pyhf comes with a lot of nifty utilities you can access. The documentation for the command line can be found via `pyhf --help` or [online](https://pyhf.readthedocs.io/en/v0.7.0/cli.html)."
    ]
   },
   {
@@ -229,7 +229,7 @@
     "python -m pip install pyhf[xmlio]\n",
     "```\n",
     "\n",
-    "Again, the online documentation for this option is found [here](https://pyhf.readthedocs.io/en/v0.6.3/cli.html#pyhf-xml2json)."
+    "Again, the online documentation for this option is found [here](https://pyhf.readthedocs.io/en/v0.7.0/cli.html#pyhf-xml2json)."
    ]
   },
   {
@@ -292,7 +292,7 @@
     "\n",
     "Nearly at the end, the next part of this specification is for the `observations` (observed data) on line 113. Each observation corresponds with the channel, where `channel1` has two bins, and `channel2` also has two bins.\n",
     "\n",
-    "Finally, we have a `version` which specifies the version of the schema used for the JSON HistFactory. In this case, we're using `1.0.0` which has the [https://pyhf.readthedocs.io/en/v0.6.3/schemas/1.0.0/workspace.json](https://pyhf.readthedocs.io/en/v0.6.3/schemas/1.0.0/workspace.json) definition which refers to the [https://pyhf.readthedocs.io/en/v0.6.3/schemas/1.0.0/defs.json](https://pyhf.readthedocs.io/en/v0.6.3/schemas/1.0.0/defs.json).\n",
+    "Finally, we have a `version` which specifies the version of the schema used for the JSON HistFactory. In this case, we're using `1.0.0` which has the [https://pyhf.readthedocs.io/en/v0.7.0/schemas/1.0.0/workspace.json](https://pyhf.readthedocs.io/en/v0.7.0/schemas/1.0.0/workspace.json) definition which refers to the [https://pyhf.readthedocs.io/en/v0.7.0/schemas/1.0.0/defs.json](https://pyhf.readthedocs.io/en/v0.7.0/schemas/1.0.0/defs.json).\n",
     "\n",
     "What's really nice about the schema definition is that it allows anyone to write their own tooling/scripting to build up the workspace and quickly check if it matches the schema. This will get you 90% of the way there in having a valid workspace to work with.\n",
     "\n",
@@ -330,7 +330,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So we're not going to dump this out. We already did that above. Let's just quickly go ahead and load it into a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.6.3/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object because we can."
+    "So we're not going to dump this out. We already did that above. Let's just quickly go ahead and load it into a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.7.0/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object because we can."
    ]
   },
   {

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -117,7 +117,7 @@ The 'minuit' extra installs [`iminuit`](https://iminuit.readthedocs.io/).
 ````
 
 
-See our [installation docs](https://pyhf.readthedocs.io/en/v0.6.3/installation.html) for more information about installation options.
+See our [installation docs](https://pyhf.readthedocs.io/en/v0.7.0/installation.html) for more information about installation options.
 
 ### Dependencies for this tutorial
 
@@ -141,11 +141,11 @@ If you want to also get the dependencies to build and explore the Jupyter Book f
 (pyhf-tutorial) $ pyhf --citation
 @software{pyhf,
   author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},
-  title = "{pyhf: v0.6.3}",
-  version = {0.6.3},
+  title = "{pyhf: v0.7.0}",
+  version = {0.7.0},
   doi = {10.5281/zenodo.1169739},
   url = {https://doi.org/10.5281/zenodo.1169739},
-  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.3}
+  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.7.0}
 }
 
 @article{pyhf_joss,
@@ -162,7 +162,7 @@ If you want to also get the dependencies to build and explore the Jupyter Book f
 }
 ```
 
-Alternatively, [check the website](https://pyhf.readthedocs.io/en/v0.6.3/citations.html).
+Alternatively, [check the website](https://pyhf.readthedocs.io/en/v0.7.0/citations.html).
 
 ### Statistics References
 


### PR DESCRIPTION
Addresses the tutorial part of https://github.com/scikit-hep/pyhf/issues/2022

```
* Update to pyhf v0.7.0 and update API changes
   - pyhf.infer.intervals.upperlimit -> pyhf.infer.intervals.upper_limits.upper_limit
   - Update URLs to point to v0.7.0
```