### PR TITLE
ci: Use container Python over setting up with GitHub Actions

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -11,7 +11,7 @@ jobs:
 
   deploy-book:
     runs-on: ubuntu-latest
-    container: atlasamglab/stats-base:root6.24.06
+    container: atlasamglab/stats-base:root6.26.10
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -16,11 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    # - name: Set up Python
-    #   uses: actions/setup-python@v4
-    #   with:
-    #     python-version: '3.10'
-
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -21,6 +21,11 @@ jobs:
       with:
         python-version: '3.10'
 
+    - name: Update glibc
+      run: |
+        apt-get update
+        apt-get install -y glibc-source
+
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -16,15 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-
-    - name: Update glibc
-      run: |
-        apt-get update
-        apt-get install -y glibc-source
+    # - name: Set up Python
+    #   uses: actions/setup-python@v4
+    #   with:
+    #     python-version: '3.10'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 


### PR DESCRIPTION
* Remove actions/setup-python GitHub Action in favor of using Python
  supplied by container to avoid possible glibc version conflicts.
* Update image to atlasamglab/stats-base:root6.26.10.