### PR TITLE
fix: Update all APIs to pyhf v0.7.0

### DIFF
--- a/book/Combinations.ipynb
+++ b/book/Combinations.ipynb
@@ -99,7 +99,6 @@
     "print(f\"       nbins: {combined_workspace.channel_nbins}\")\n",
     "print(f\"     samples: {combined_workspace.samples}\")\n",
     "print(f\"   modifiers: {combined_workspace.modifiers}\")\n",
-    "print(f\"  parameters: {combined_workspace.model().config.parameters}\")\n",
     "print(f\"measurements: {combined_workspace.measurement_names}\")"
    ]
   },

--- a/book/Combinations.ipynb
+++ b/book/Combinations.ipynb
@@ -99,7 +99,7 @@
     "print(f\"       nbins: {combined_workspace.channel_nbins}\")\n",
     "print(f\"     samples: {combined_workspace.samples}\")\n",
     "print(f\"   modifiers: {combined_workspace.modifiers}\")\n",
-    "print(f\"  parameters: {combined_workspace.parameters}\")\n",
+    "print(f\"  parameters: {combined_workspace.model().config.parameters}\")\n",
     "print(f\"measurements: {combined_workspace.measurement_names}\")"
    ]
   },

--- a/book/SimpleWorkspace.ipynb
+++ b/book/SimpleWorkspace.ipynb
@@ -149,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workspace.get_measurement(poi_name=\"mu\")"
+    "workspace.get_measurement(measurement_name=\"mu\")"
    ]
   },
   {

--- a/book/SimpleWorkspace.ipynb
+++ b/book/SimpleWorkspace.ipynb
@@ -140,22 +140,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or create a new measurement on the fly by specifying the name for the parameter of interest:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "workspace.get_measurement(measurement_name=\"mu\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "What does this mean for us though? Well, when we ask for a model, we specify the measurement that we want to use with it. Each of these measurements above have no additional parameter configurations on top of the existing model specification. Additionally, they all declare that the parameter of interest is `mu`.\n",
     "\n",
     "See the [documentation](https://pyhf.readthedocs.io/en/v0.7.0/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace.model) for more information. In this case, let's build the model for the default measurement."
@@ -241,7 +225,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -255,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -344,7 +344,6 @@
     "print(f\"       nbins: {ws.channel_nbins}\")\n",
     "print(f\"     samples: {ws.samples}\")\n",
     "print(f\"   modifiers: {ws.modifiers}\")\n",
-    "print(f\"  parameters: {ws.model().config.parameters}\")\n",
     "print(f\"observations: {ws.observations}\")"
    ]
   },

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -344,7 +344,7 @@
     "print(f\"       nbins: {ws.channel_nbins}\")\n",
     "print(f\"     samples: {ws.samples}\")\n",
     "print(f\"   modifiers: {ws.modifiers}\")\n",
-    "print(f\"  parameters: {ws.parameters}\")\n",
+    "print(f\"  parameters: {ws.model().config.parameters}\")\n",
     "print(f\"observations: {ws.observations}\")"
    ]
   },


### PR DESCRIPTION
Resolves #33 

Amends PR #29 

```
* Update all APIs to be consistent with v0.7.0.
   - Remove comment about making measurement on the fly with
     `workspace.get_measurement` as no longer relevant.
   - Remove all use of `workspace.parameters`, now
     `workspace.model().config.parameters`, as the notebooks
      are focusing on workspace attributes, not model config
      attributes.
* Amends PR #29
```