### PR TITLE
feat: Update Jupyter Book to v0.13.2

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -19,8 +19,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir install -r binder/requirements.txt
-        python -m pip --no-cache-dir install -r book/requirements.txt
+        python -m pip --no-cache-dir install --requirement binder/requirements.txt --requirement book/requirements.txt
 
     - name: List installed Python packages
       run: |

--- a/book/requirements.txt
+++ b/book/requirements.txt
@@ -1,1 +1,1 @@
-jupyter-book==0.12.1
+jupyter-book==0.13.2


### PR DESCRIPTION
```
* Update juptyer-book to v0.13.2 to be compatible with jsonschema requirements
  of pyhf v0.7.0.
* Install binder/requirements.txt and book/requirements.txt at the same time to
  force dependency resolution for both requirements files in the same environment.
```