### PR TITLE
chore: Update Binder runtime to Python 3.11

### DIFF
--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10
+python-3.11


### PR DESCRIPTION
* As of pyhf v0.7.1 all backends support Python 3.11.