### PR TITLE
fix: Resize logo to fit page

### DIFF
--- a/book/introduction.md
+++ b/book/introduction.md
@@ -3,7 +3,7 @@
 ## Welcome!
 
 <p align="center">
-<a href="https://github.com/scikit-hep/pyhf"><img src="https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/_static/img/pyhf-logo.svg"></a>
+<a href="https://github.com/scikit-hep/pyhf"><img src="https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/_static/img/pyhf-logo.svg" width="45%"></a>
 </p>
 
 Welcome to the `pyhf` tutorial!


### PR DESCRIPTION
* Set the logo size to be reasonably centered in the page.
* Amends PR #45.

```
* Set the logo size by setting the width to be a percentage of the middle
  page column width. Using a percentage allows for the image size to be
  reactive to page adjustments and resizing.
* Amends PR https://github.com/pyhf/pyhf-tutorial/pull/45.
```