### PR TITLE
ci: Deploy jupyter book with GitHub Pages action

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -7,6 +7,16 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
 
   deploy-book:
@@ -29,14 +39,24 @@ jobs:
       run: |
         jupyter-book build book/
 
-    - name: Deploy Jupyter book to GitHub pages
-      # Deploy either on push events (merged PRs) or workflow dispatch triggers
+    - name: Setup Pages
       if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: actions/configure-pages@v2
+
+    - name: Fix permissions
+      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      run: |
+        chmod -c -R +rX "book/_build/html/" | while read line; do
+          echo "::warning title=Invalid file permissions automatically fixed::$line"
+        done
+
+    - name: Upload artifact
+      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      uses: actions/upload-pages-artifact@v2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: book/_build/html
-        force_orphan: true
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: Deploy to GitHub pages
+        path: 'book/_build/html'
+
+    - name: Deploy to GitHub Pages
+      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      id: deployment
+      uses: actions/deploy-pages@v1


### PR DESCRIPTION
```
* Deploy the jupyter book website to GitHub Pages using GitHub Actions.
   - actions/configure-pages
   - actions/upload-pages-artifact
   - actions/deploy-pages
```