### PR TITLE
ci: Add Pyodide build and JupyterLite based view

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
 
-  deploy-book:
+  build-book:
     runs-on: ubuntu-latest
     container: atlasamglab/stats-base:root6.28.04
 
@@ -39,24 +39,77 @@ jobs:
       run: |
         jupyter-book build book/
 
+    - name: Upload jupyter book
+      uses: actions/upload-artifact@v3
+      with:
+        name: jupyterbook
+        path: _build/html/
+
+  build-pyodide:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+
+    - name: Install pyodide
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade "jupyterlite[lab]"
+
+    - name: List installed Python packages
+      run: |
+        python -m pip list
+
+    - name: Build the Pyodide output
+      run: |
+        jupyter lite init
+        jupyter lite build --contents=book
+
+    - name: Upload Pyodide build
+      uses: actions/upload-artifact@v3
+      with:
+        name: jupyterlite
+        path: _output/
+
+  deploy-book:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: [build-book, build-pyodide]
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+
+    steps:
+
     - name: Setup Pages
-      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: actions/configure-pages@v2
 
+    - uses: actions/download-artifact@v3
+      with:
+        name: jupyterbook
+        path: 'public'
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: jupyterlite
+        path: 'public/live'
+
     - name: Fix permissions
-      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       run: |
-        chmod -c -R +rX "book/_build/html/" | while read line; do
+        chmod -c -R +rX "public/" | while read line; do
           echo "::warning title=Invalid file permissions automatically fixed::$line"
         done
 
     - name: Upload artifact
-      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: actions/upload-pages-artifact@v2
       with:
-        path: 'book/_build/html'
+        path: 'public'
 
     - name: Deploy to GitHub Pages
-      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       id: deployment
       uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: jupyterbook
-        path: _build/html/
+        path: 'book/_build/html/'
 
   build-pyodide:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -74,8 +74,10 @@ jobs:
 
     - name: Build the Pyodide output
       run: |
+        jupyter lite --help
         jupyter lite init
         jupyter lite build --contents=book
+        jupyter lite check
 
     - name: Upload Pyodide build
       uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -82,7 +82,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: [build-book, build-pyodide]
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     steps:
 

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -14,7 +14,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -59,11 +59,18 @@ jobs:
     - name: Install pyodide
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade "jupyterlite[lab]"
+        python -m pip install --upgrade \
+          "jupyterlite[lab]" \
+          "jupytext>=1.14.0"
 
     - name: List installed Python packages
       run: |
         python -m pip list
+
+    - name: Convert .py to notebook
+      run: |
+        jupytext --to notebook lite/jupyterlite.py
+        cp lite/jupyterlite.ipynb  book/index.ipynb
 
     - name: Build the Pyodide output
       run: |
@@ -76,7 +83,7 @@ jobs:
         name: jupyterlite
         path: _output/
 
-  deploy-book:
+  deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -2,8 +2,8 @@ name: Deploy Jupyter Book
 
 on:
   push:
-    branches:
-    - main
+    # branches:
+    # - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Convert .py to notebook
       run: |
         jupytext --to notebook lite/jupyterlite.py
-        cp lite/jupyterlite.ipynb  book/index.ipynb
+        cp lite/*.ipynb  book/
 
     - name: Build the Pyodide output
       run: |

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -2,8 +2,8 @@ name: Deploy Jupyter Book
 
 on:
   push:
-    # branches:
-    # - main
+    branches:
+    - main
   pull_request:
   workflow_dispatch:
 
@@ -91,7 +91,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: [build-book, build-pyodide]
-    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Tutorial last given at the [April 2021 PyHEP topical meeting](https://indico.cer
 **The tutorial is based off of [`pyhf` `v0.7.2`](https://pypi.org/project/pyhf/0.7.2/)**
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyhf/pyhf-tutorial/main?urlpath=lab)
+[![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://pyhf.github.io/pyhf-tutorial/live/lab/index.html?path=jupyterlite.ipynb)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4670321.svg)](https://doi.org/10.5281/zenodo.4670321)
 
 [![Deploy Jupyter Book](https://github.com/pyhf/pyhf-tutorial/workflows/Deploy%20Jupyter%20Book/badge.svg?branch=main)](https://pyhf.github.io/pyhf-tutorial/)

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -71,7 +71,7 @@ $ source pyhf-tutorial/bin/activate
 ```
 :::
 
-:::{tab-item} In your browser with WebAssembly
+:::{tab-item} In your browser
 
 As `pyhf` is pure Python it is possible to install and run a version of it directly in your browser using [Pyodide](https://pyodide.org/).
 You can try out the live WebAssembly version of the user guide in [JupyterLite](https://jupyterlite.readthedocs.io/) now by visiting the [live view of the website](https://pyhf.github.io/pyhf-tutorial/live/lab/index.html?path=jupyterlite.ipynb).

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -71,6 +71,15 @@ $ source pyhf-tutorial/bin/activate
 ```
 :::
 
+:::{tab-item} In your browser with WebAssembly
+
+As `pyhf` is pure Python it is possible to install and run a version of it directly in your browser using [Pyodide](https://pyodide.org/).
+You can try out the live WebAssembly version of the user guide in [JupyterLite](https://jupyterlite.readthedocs.io/) now by visiting the [live view of the website](https://pyhf.github.io/pyhf-tutorial/live/lab/index.html?path=jupyterlite.ipynb).
+
+Not all parts of this user guide are able to run in Pyodide, but the pure Python parts will work.
+
+:::
+
 ::::
 
 Once you have a virtual environment set up, you can use `source pyhf-tutorial/bin/activate` to get back into it again. Note the prefix `(pyhf-tutorial) $` on your command line, which indicates that you're inside a virtual environment named 'pyhf-tutorial'.

--- a/lite/jupyterlite.py
+++ b/lite/jupyterlite.py
@@ -1,0 +1,27 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Python (Pyodide)
+#     language: python
+#     name: python
+# ---
+
+# %% [markdown]
+# # `pyhf` in the browser
+
+# %% [markdown]
+# * To run the code, click on the first cell (gray box) and press <kbd>Shift</kbd>+<kbd>Enter</kbd> or click on the (Run) ▶ button to run each cell.
+# * Alternatively, from the `Run` menu select `Run All Cells`.
+# * Feel free to experiment, and if you need to restore the original code reload this browser page. Any changes you make will be lost when you reload.
+#
+# To get going try copying and pasting the "Hello World" example below!
+
+# %%
+import piplite
+
+# Install pyhf in the browser
+await piplite.install(["pyhf==0.7.2", "matplotlib>=3.0.0"])
+# %matplotlib inline
+import pyhf
+
+# You can now use pyhf!

--- a/lite/jupyterlite.py
+++ b/lite/jupyterlite.py
@@ -16,11 +16,20 @@
 # You will need to copy and paste the following block into the top of each notebook.
 
 # %%
-import piplite
+import micropip
 
 # Install pyhf in the browser
-await piplite.install(["pyhf==0.7.2", "matplotlib>=3.0.0"])
+await micropip.install(["pyhf==0.7.2", "matplotlib>=3.0.0"])
 # %matplotlib inline
 import pyhf
 
 # You can now use pyhf!
+
+# %% [markdown]
+# Based on the way that Pyodide works with [third party packages](https://pyodide.org/en/stable/usage/packages-in-pyodide.html), you'll need to place the following cell at the top of each notebook that you'll use `pyhf` in.
+
+# %%
+import micropip
+
+# Install pyhf in the browser
+await micropip.install(["pyhf==0.7.2", "matplotlib>=3.0.0"])

--- a/lite/jupyterlite.py
+++ b/lite/jupyterlite.py
@@ -12,9 +12,8 @@
 # %% [markdown]
 # * To run the code, click on the first cell (gray box) and press <kbd>Shift</kbd>+<kbd>Enter</kbd> or click on the (Run) ▶ button to run each cell.
 # * Alternatively, from the `Run` menu select `Run All Cells`.
-# * Feel free to experiment, and if you need to restore the original code reload this browser page. Any changes you make will be lost when you reload.
 #
-# To get going try copying and pasting the "Hello World" example below!
+# You will need to copy and paste the following block into the top of each notebook.
 
 # %%
 import piplite

--- a/lite/jupyterlite.py
+++ b/lite/jupyterlite.py
@@ -12,8 +12,6 @@
 # %% [markdown]
 # * To run the code, click on the first cell (gray box) and press <kbd>Shift</kbd>+<kbd>Enter</kbd> or click on the (Run) ▶ button to run each cell.
 # * Alternatively, from the `Run` menu select `Run All Cells`.
-#
-# You will need to copy and paste the following block into the top of each notebook.
 
 # %%
 import micropip

--- a/lite/jupytext.toml
+++ b/lite/jupytext.toml
@@ -1,0 +1,3 @@
+# Always pair ipynb notebooks in the current directory to py:percent files
+formats = ["ipynb", "py:percent"]
+notebook_metadata_filter = "-all,kernelspec"


### PR DESCRIPTION
```
* Add Pyodide build using JupyterLite.
* Split GitHub Pages build into a JupyterBook build and a Pyodide build and
  require both to succeed and upload to deploy the website.
* Add jupyterlite.ipynb example notebook to guide users.
   - Use jupytext to keep this as a .py file.
* Add WebAssembly live page link to introduction that opens to jupyterlite.ipynb.
* Add JupyterLite view badge to README.

Co-authored-by: Henry Schreiner <henry.fredrick.schreiner@cern.ch>
```

[![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://pyhf.github.io/pyhf-tutorial/live/lab/index.html?path=jupyterlite.ipynb)

Based on @henryiii's https://github.com/henryiii/level-up-your-python