### PR TITLE
fix: Set notebook cell timeout to 2 minutes

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -5,7 +5,7 @@ author: the pyhf development team
 logo: assets/pyhf-logo.svg
 
 execute:
-  timeout: 300  # seconds (5 minutes)
+  timeout: 120  # seconds (2 minutes)
 
 # HTML-specific settings
 html:

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -4,6 +4,9 @@ title: 'pyhf Tutorial'
 author: the pyhf development team
 logo: assets/pyhf-logo.svg
 
+execute:
+  timeout: 300  # seconds (5 minutes)
+
 # HTML-specific settings
 html:
   use_repository_button: true

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -5,7 +5,7 @@ author: the pyhf development team
 logo: assets/pyhf-logo.svg
 
 execute:
-  timeout: 120  # seconds (2 minutes)
+  timeout: 120  # seconds
 
 # HTML-specific settings
 html:


### PR DESCRIPTION
* Resolves #60 
* Resolves #13 

To allow for long running processes that require actual computation extend the notebook cell timeout from the default 30 seconds to 120 seconds (2 minutes).
   - c.f. https://jupyterbook.org/en/stable/customize/config.html

```
* To allow for long running processes that require actual computation
  extend the notebook cell timeout from the default 30 seconds to 120
  seconds (2 minutes).
   - c.f. https://jupyterbook.org/en/stable/customize/config.html
```