### PR TITLE
fix: Use correct model for low stats demonstration

### DIFF
--- a/book/Toys.ipynb
+++ b/book/Toys.ipynb
@@ -86,7 +86,7 @@
     "    test_stat=\"qtilde\",\n",
     "    return_expected_set=True,\n",
     "    calctype=\"toybased\",\n",
-    "    ntoys=1000,\n",
+    "    ntoys=1_000,\n",
     "    track_progress=False,\n",
     ")\n",
     "print(f\"      Observed CLs: {CLs_obs:.4f}\")\n",
@@ -136,8 +136,8 @@
    "source": [
     "CLs_obs, CLs_exp = pyhf.infer.hypotest(\n",
     "    1.0,  # null hypothesis\n",
-    "    [5.0, 7.0] + model.config.auxdata,\n",
-    "    model,\n",
+    "    [5.0, 7.0] + model_low.config.auxdata,\n",
+    "    model_low,\n",
     "    test_stat=\"qtilde\",\n",
     "    return_expected_set=True,\n",
     "    calctype=\"asymptotics\",\n",
@@ -151,7 +151,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And now throwing 2000 toys:"
+    "And now throwing 5000 toys:"
    ]
   },
   {
@@ -162,12 +162,12 @@
    "source": [
     "CLs_obs, CLs_exp = pyhf.infer.hypotest(\n",
     "    1.0,  # null hypothesis\n",
-    "    [5.0, 7.0] + model.config.auxdata,\n",
-    "    model,\n",
+    "    [5.0, 7.0] + model_low.config.auxdata,\n",
+    "    model_low,\n",
     "    test_stat=\"qtilde\",\n",
     "    return_expected_set=True,\n",
     "    calctype=\"toybased\",\n",
-    "    ntoys=1000,\n",
+    "    ntoys=5_000,\n",
     "    track_progress=False,\n",
     ")\n",
     "print(f\"      Observed CLs: {CLs_obs:.4f}\")\n",
@@ -185,7 +185,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -199,7 +199,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Resolves #63 

* Use the correct model (`model_low`) for demonstration of the difference between the asymptotics based and toy based calculators.
   - Amends PR https://github.com/pyhf/pyhf-tutorial/pull/1
* Use 5000 pseudo-experiments to demonstrate the difference more effectively.
* Use underscores in numeric literals (5_000) for better readability.
   - c.f. https://peps.python.org/pep-0515/

```
* Use the correct model (`model_low`) for demonstration of the
  difference between the asymptotics based and toy based calculators.
   - Amends PR https://github.com/pyhf/pyhf-tutorial/pull/1
* Use 5000 pseudo-experiments to demonstrate the difference more
  effectively.
* Use underscores in numeric literals (5_000) for better readability.
   - c.f. https://peps.python.org/pep-0515/
```