### PR TITLE
fix: Update notebook cell timeout for toys notebook

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -5,7 +5,7 @@ author: the pyhf development team
 logo: assets/pyhf-logo.svg
 
 execute:
-  timeout: 120  # seconds
+  timeout: 210  # seconds
 
 # HTML-specific settings
 html:


### PR DESCRIPTION
* Update cell timeout to 210 seconds to allow for sufficient time for the pseudo-experiments to run in book/Toys.ipynb.