### PR TITLE
feat: Update pyhf to v0.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `pyhf` Tutorial
 
-**The tutorial is based off of [`pyhf` `v0.7.4`](https://pypi.org/project/pyhf/0.7.4/)**
+**The tutorial is based off of [`pyhf` `v0.7.5`](https://pypi.org/project/pyhf/0.7.5/)**
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyhf/pyhf-tutorial/main?urlpath=lab)
 [![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://pyhf.github.io/pyhf-tutorial/live/lab/index.html?path=jupyterlite.ipynb)

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-pyhf[xmlio,minuit,contrib]==0.7.4
+pyhf[xmlio,minuit,contrib]==0.7.5
 # visualization
 ipywidgets~=8.1.1
 ipympl~=0.9.3

--- a/book/HelloWorld.ipynb
+++ b/book/HelloWorld.ipynb
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What did we just make? This returns a [`pyhf.pdf.Model`](https://pyhf.readthedocs.io/en/v0.7.4/_generated/pyhf.pdf.Model.html#pyhf.pdf.Model) object. Let's check out the specification."
+    "What did we just make? This returns a [`pyhf.pdf.Model`](https://pyhf.readthedocs.io/en/v0.7.5/_generated/pyhf.pdf.Model.html#pyhf.pdf.Model) object. Let's check out the specification."
    ]
   },
   {
@@ -144,7 +144,7 @@
     "\n",
     "where $n = \\{n_1, n_2\\}$ for a 2-bin model (we're being slightly fast and loose with our mathematical notation here), and similarly for $s$, $b$, and $\\gamma$.\n",
     "\n",
-    "The 'shapesys' is defined in the [HistFactory paper](https://cds.cern.ch/record/1456844)... however, it can be a little hard to extract out the necessary information. We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.7.4/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
+    "The 'shapesys' is defined in the [HistFactory paper](https://cds.cern.ch/record/1456844)... however, it can be a little hard to extract out the necessary information. We've provided a nice table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.7.5/intro.html#id24) in the introduction of our pyhf documentation to use as reference.\n",
     "\n",
     "![modifiers and constraints](assets/modifiers_and_constraints.png)"
    ]
@@ -515,7 +515,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're not performing inference just yet. We're simply computing the 'logpdf' of the model specified by the parameters $\\theta$ against the provided data. To perform a fit, we use the [inference API](https://pyhf.readthedocs.io/en/v0.7.4/api.html#inference) via `pyhf.infer`.\n",
+    "We're not performing inference just yet. We're simply computing the 'logpdf' of the model specified by the parameters $\\theta$ against the provided data. To perform a fit, we use the [inference API](https://pyhf.readthedocs.io/en/v0.7.5/api.html#inference) via `pyhf.infer`.\n",
     "\n",
     "When fitting a model to data, we usually want to find the $\\hat{\\theta}$ which refers to the \"Maximum Likelihood Estimate\" of the model parameters. This is often referred to mathematically by\n",
     "\n",
@@ -675,7 +675,7 @@
    "source": [
     "## Simple Upper Limit\n",
     "\n",
-    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upper_limits.upper_limit` API](https://pyhf.readthedocs.io/en/v0.7.4/_generated/pyhf.infer.intervals.upper_limits.upper_limit.html#pyhf.infer.intervals.upper_limits.upper_limit), which also can calculate the upper limit by interpolating"
+    "To get upper limits, we just need to run multiple hypothesis tests for a lot of different null hypotheses of BSM with $\\mu \\in [0, \\ldots, 5.0]$ and then find the value of $\\mu$ for which the null hypothesis is rejected (a 95% $\\text{CL}_\\text{s}$). We can do all of this very easily just using the [`upper_limits.upper_limit` API](https://pyhf.readthedocs.io/en/v0.7.5/_generated/pyhf.infer.intervals.upper_limits.upper_limit.html#pyhf.infer.intervals.upper_limits.upper_limit), which also can calculate the upper limit by interpolating"
    ]
   },
   {

--- a/book/Modifiers.ipynb
+++ b/book/Modifiers.ipynb
@@ -8,9 +8,9 @@
    "source": [
     "# Modifiers\n",
     "\n",
-    "In our simple examples so far, we've only used two types of modifiers, but HistFactory allows for a handful of modifiers that have proven to be sufficient to model a wide range of uncertainties. Each of the modifiers is further described in the [Modifiers section](https://pyhf.readthedocs.io/en/v0.7.4/likelihood.html#modifiers) of the pyhf docs on model specification.\n",
+    "In our simple examples so far, we've only used two types of modifiers, but HistFactory allows for a handful of modifiers that have proven to be sufficient to model a wide range of uncertainties. Each of the modifiers is further described in the [Modifiers section](https://pyhf.readthedocs.io/en/v0.7.5/likelihood.html#modifiers) of the pyhf docs on model specification.\n",
     "\n",
-    "There is an addtional table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.7.4/intro.html#id24) in the introduction of the pyhf documentation to use as reference.\n",
+    "There is an addtional table of [Modifiers and Constraints](https://pyhf.readthedocs.io/en/v0.7.5/intro.html#id24) in the introduction of the pyhf documentation to use as reference.\n",
     "\n",
     "![modifiers and constraints](assets/modifiers_and_constraints.png)\n",
     "\n",

--- a/book/SerializationAndPatching.ipynb
+++ b/book/SerializationAndPatching.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "## Patching in Signals\n",
     "\n",
-    "Let's look at this [`pyhf.PatchSet`](https://pyhf.readthedocs.io/en/v0.7.4/_generated/pyhf.patchset.PatchSet.html#pyhf.patchset.PatchSet) object which provides a user-friendly way to interact with many signal patches at once.\n",
+    "Let's look at this [`pyhf.PatchSet`](https://pyhf.readthedocs.io/en/v0.7.5/_generated/pyhf.patchset.PatchSet.html#pyhf.patchset.PatchSet) object which provides a user-friendly way to interact with many signal patches at once.\n",
     "\n",
     "### PatchSet"
    ]

--- a/book/SimpleWorkspace.ipynb
+++ b/book/SimpleWorkspace.ipynb
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What did we just make? This returns a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.7.4/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object. Let's check out the specification."
+    "What did we just make? This returns a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.7.5/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object. Let's check out the specification."
    ]
   },
   {
@@ -142,7 +142,7 @@
    "source": [
     "What does this mean for us though? Well, when we ask for a model, we specify the measurement that we want to use with it. Each of these measurements above have no additional parameter configurations on top of the existing model specification. Additionally, they all declare that the parameter of interest is `mu`.\n",
     "\n",
-    "See the [documentation](https://pyhf.readthedocs.io/en/v0.7.4/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace.model) for more information. In this case, let's build the model for the default measurement."
+    "See the [documentation](https://pyhf.readthedocs.io/en/v0.7.5/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace.model) for more information. In this case, let's build the model for the default measurement."
    ]
   },
   {

--- a/book/WorkspaceManipulations.ipynb
+++ b/book/WorkspaceManipulations.ipynb
@@ -207,7 +207,7 @@
     "\n",
     "### via the command line\n",
     "\n",
-    "So pyhf comes with a lot of nifty utilities you can access. The documentation for the command line can be found via `pyhf --help` or [online](https://pyhf.readthedocs.io/en/v0.7.4/cli.html)."
+    "So pyhf comes with a lot of nifty utilities you can access. The documentation for the command line can be found via `pyhf --help` or [online](https://pyhf.readthedocs.io/en/v0.7.5/cli.html)."
    ]
   },
   {
@@ -229,7 +229,7 @@
     "python -m pip install pyhf[xmlio]\n",
     "```\n",
     "\n",
-    "Again, the online documentation for this option is found [here](https://pyhf.readthedocs.io/en/v0.7.4/cli.html#pyhf-xml2json)."
+    "Again, the online documentation for this option is found [here](https://pyhf.readthedocs.io/en/v0.7.5/cli.html#pyhf-xml2json)."
    ]
   },
   {
@@ -292,7 +292,7 @@
     "\n",
     "Nearly at the end, the next part of this specification is for the `observations` (observed data) on line 113. Each observation corresponds with the channel, where `channel1` has two bins, and `channel2` also has two bins.\n",
     "\n",
-    "Finally, we have a `version` which specifies the version of the schema used for the JSON HistFactory. In this case, we're using `1.0.0` which has the [https://pyhf.readthedocs.io/en/v0.7.4/schemas/1.0.0/workspace.json](https://pyhf.readthedocs.io/en/v0.7.4/schemas/1.0.0/workspace.json) definition which refers to the [https://pyhf.readthedocs.io/en/v0.7.4/schemas/1.0.0/defs.json](https://pyhf.readthedocs.io/en/v0.7.4/schemas/1.0.0/defs.json).\n",
+    "Finally, we have a `version` which specifies the version of the schema used for the JSON HistFactory. In this case, we're using `1.0.0` which has the [https://pyhf.readthedocs.io/en/v0.7.5/schemas/1.0.0/workspace.json](https://pyhf.readthedocs.io/en/v0.7.5/schemas/1.0.0/workspace.json) definition which refers to the [https://pyhf.readthedocs.io/en/v0.7.5/schemas/1.0.0/defs.json](https://pyhf.readthedocs.io/en/v0.7.5/schemas/1.0.0/defs.json).\n",
     "\n",
     "What's really nice about the schema definition is that it allows anyone to write their own tooling/scripting to build up the workspace and quickly check if it matches the schema. This will get you 90% of the way there in having a valid workspace to work with.\n",
     "\n",
@@ -330,7 +330,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So we're not going to dump this out. We already did that above. Let's just quickly go ahead and load it into a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.7.4/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object because we can."
+    "So we're not going to dump this out. We already did that above. Let's just quickly go ahead and load it into a [`pyhf.Workspace`](https://pyhf.readthedocs.io/en/v0.7.5/_generated/pyhf.workspace.Workspace.html#pyhf.workspace.Workspace) object because we can."
    ]
   },
   {

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -130,7 +130,7 @@ The 'minuit' extra installs [`iminuit`](https://iminuit.readthedocs.io/).
 
 ::::
 
-See our [installation docs](https://pyhf.readthedocs.io/en/v0.7.4/installation.html) for more information about installation options.
+See our [installation docs](https://pyhf.readthedocs.io/en/v0.7.5/installation.html) for more information about installation options.
 
 ### Dependencies for this tutorial
 
@@ -161,11 +161,11 @@ If you want to also get the dependencies to build and explore the Jupyter Book f
 (pyhf-tutorial) $ pyhf --citation
 @software{pyhf,
   author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},
-  title = "{pyhf: v0.7.4}",
-  version = {0.7.4},
+  title = "{pyhf: v0.7.5}",
+  version = {0.7.5},
   doi = {10.5281/zenodo.1169739},
   url = {https://doi.org/10.5281/zenodo.1169739},
-  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.7.4}
+  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.7.5}
 }
 
 @article{pyhf_joss,
@@ -182,7 +182,7 @@ If you want to also get the dependencies to build and explore the Jupyter Book f
 }
 ```
 
-Alternatively, [check the website](https://pyhf.readthedocs.io/en/v0.7.4/citations.html).
+Alternatively, [check the website](https://pyhf.readthedocs.io/en/v0.7.5/citations.html).
 
 ### Statistics References
 

--- a/book/requirements.lock
+++ b/book/requirements.lock
@@ -1218,9 +1218,9 @@ pygments==2.16.1 \
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyhf[contrib,minuit,xmlio]==0.7.4 \
-    --hash=sha256:76b73d6e91b169bb1fd3d011375ca0340ec353730ad7f3a006e80331f63ec123 \
-    --hash=sha256:92c148ec1e07b04a72d60a2d7ac9202c92813c453daa9a443e05485e02c88ee3
+pyhf[contrib,minuit,xmlio]==0.7.5 \
+    --hash=sha256:51aa26bb87c13f493221371e94e693528378779137499029801f99cc10d8d5b2 \
+    --hash=sha256:83a73f1f662c5be3aa15126351eb29c5154c000d87e2a5d9f0f9f9df20b1c28c
     # via -r requirements.txt
 pyparsing==3.1.1 \
     --hash=sha256:32c7c0b711493c72ff18a981d24f28aaf9c1fb7ed5e9667c9e84e3db623bdbfb \

--- a/lite/jupyterlite.py
+++ b/lite/jupyterlite.py
@@ -17,7 +17,7 @@
 import micropip
 
 # Install pyhf in the browser
-await micropip.install(["pyhf==0.7.4", "matplotlib>=3.0.0"])
+await micropip.install(["pyhf==0.7.5", "matplotlib>=3.0.0"])
 # %matplotlib inline
 import pyhf
 
@@ -30,4 +30,4 @@ import pyhf
 import micropip
 
 # Install pyhf in the browser
-await micropip.install(["pyhf==0.7.4", "matplotlib>=3.0.0"])
+await micropip.install(["pyhf==0.7.5", "matplotlib>=3.0.0"])


### PR DESCRIPTION
* Update to pyhf v0.7.5.
   - Update URLs to point to v0.7.5.
* Update requirements.txt and upgrade lock file.
   - Using 'pip-compile --generate-hashes --upgrade-package pyhf'