### PR TITLE
ci: Use pixi for book build

### DIFF
--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -21,19 +21,19 @@ jobs:
 
   build-book:
     runs-on: ubuntu-latest
-    container: atlasamglab/stats-base:root6.28.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --no-deps --require-hashes --requirement book/requirements.lock
+    - name: Set up pixi
+      uses: prefix-dev/setup-pixi@v0.8.1
+      with:
+        cache: true
+        cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
-    - name: List installed Python packages
+    - name: List installed packages
       run: |
-        python -m pip list
+        pixi list --environment book
 
     - name: Set track_progress=False for notebooks
       run: |
@@ -42,7 +42,7 @@ jobs:
 
     - name: Build the book
       run: |
-        jupyter-book build book/
+        pixi run build
 
     - name: Upload jupyter book
       uses: actions/upload-artifact@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,19 +15,18 @@ jobs:
         python-version: [ '3.x' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install pre-commit
-        pre-commit install
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        version: "latest"
 
     - name: Lint with pre-commit
       run: |
-        pre-commit run --all-files
+        uvx pre-commit run --all-files

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -8,4 +8,4 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 
 # Use mamba to speed up install
-mamba install --yes root
+mamba install --yes root_base

--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10
+python-3.12


### PR DESCRIPTION
```
* Update GitHub Actions.
   - actions/checkout@v3 -> actions/checkout@v4
   - actions/setup-python@v4 -> actions/setup-python@v5
* Use prefix-dev/setup-pixi to setup pixi and load environment.
   - Remove use of ROOT Docker image.
* Use pixi commands to build Jupyter book
   - This significantly speeds up the build in CI by multiple minutes.
* Use uvx for lint workflow.
* Use root_base in Binder postBuild.
* Update Binder Python to 3.12.
```