### PR TITLE
ci: Update GitHub actions and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "github-actions"
+      - "dependencies"
+    reviewers:
+      - "matthewfeickert"

--- a/.github/workflows/deploy-jupyter-book.yml
+++ b/.github/workflows/deploy-jupyter-book.yml
@@ -45,7 +45,7 @@ jobs:
         pixi run build
 
     - name: Upload jupyter book
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: jupyterbook
         path: 'book/_build/html/'
@@ -89,7 +89,7 @@ jobs:
         jupyter lite check
 
     - name: Upload Pyodide build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: jupyterlite
         path: _output/
@@ -105,14 +105,14 @@ jobs:
     steps:
 
     - name: Setup Pages
-      uses: actions/configure-pages@v2
+      uses: actions/configure-pages@v5
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: jupyterbook
         path: 'public'
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: jupyterlite
         path: 'public/live'
@@ -124,10 +124,10 @@ jobs:
         done
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: 'public'
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
* actions/upload-artifact v3 -> v4.
* actions/download-artifact v3 -> v4.
* actions/configure-pages v2 -> v5.
* actions/upload-pages-artifact v2 -> v3.
* actions/deploy-pages v1 -> v4.
* Add Dependabot config for monthly GitHub Actions updates.