### PR TITLE
docs: Note 'uv pip compile' is tool used

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ make build
 
 ## Build lock file
 
-To build a `pip-compile` lock file for local use `nox`
+To build a `uv pip compile` lock file for local use `nox`
 
 ```
 nox


### PR DESCRIPTION
* 'uv pip compile' is the tool used to build the requirements.lock lock file.
   - Amends PR https://github.com/pyhf/pyhf-tutorial/pull/86.