### PR TITLE
chore: Add CODEOWNERS file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,3 @@ updates:
     labels:
       - "github-actions"
       - "dependencies"
-    reviewers:
-      - "matthewfeickert"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @matthewfeickert @kratsg


### PR DESCRIPTION
* Add `CODEOWNERS` file to add reviewers as Dependabot reviewers configuration option is being removed.
   - c.f. https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
   - c.f. https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location